### PR TITLE
Remove internal modifier for WheelPicker

### DIFF
--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
@@ -24,7 +24,7 @@ import kotlin.math.abs
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-internal fun WheelPicker(
+fun WheelPicker(
   modifier: Modifier = Modifier,
   startIndex: Int = 0,
   count: Int,


### PR DESCRIPTION
Removed internal modifier so that others can create all sorts of different types of wheel pickers

Issue #2 