### PR TITLE
Arabic localization enhancement

### DIFF
--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
@@ -62,7 +62,7 @@ internal fun WheelPicker(
     LazyColumn(
       modifier = Modifier
         .height(size.height)
-        .widthIn(size.width),
+        .width(size.width),
       state = lazyListState,
       contentPadding = PaddingValues(vertical = size.height / rowCount * ((rowCount - 1) / 2)),
       flingBehavior = flingBehavior
@@ -77,7 +77,7 @@ internal fun WheelPicker(
         Box(
           modifier = Modifier
             .height(size.height / rowCount)
-            .widthIn(size.width)
+            .width(size.width)
             .alpha(newAlpha)
             .graphicsLayer {
               rotationX = newRotationX

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
@@ -62,7 +62,7 @@ internal fun WheelPicker(
     LazyColumn(
       modifier = Modifier
         .height(size.height)
-        .width(size.width),
+        .widthIn(size.width),
       state = lazyListState,
       contentPadding = PaddingValues(vertical = size.height / rowCount * ((rowCount - 1) / 2)),
       flingBehavior = flingBehavior
@@ -77,7 +77,7 @@ internal fun WheelPicker(
         Box(
           modifier = Modifier
             .height(size.height / rowCount)
-            .width(size.width)
+            .widthIn(size.width)
             .alpha(newAlpha)
             .graphicsLayer {
               rotationX = newRotationX

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/format/TimeFormatter.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/format/TimeFormatter.kt
@@ -76,7 +76,7 @@ fun timeFormatter(
     timeFormatter(
       strings = lyricist.strings,
       timeFormat = when {
-        locale.language == "en" || locale.region in listOf("US", "GB") -> TimeFormat.AM_PM
+        listOf("en", "ar").contains(locale.language)  || locale.region in listOf("US", "GB") -> TimeFormat.AM_PM
         else -> TimeFormat.HOUR_24
       }
     )

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/format/TimeFormatter.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/format/TimeFormatter.kt
@@ -82,3 +82,19 @@ fun timeFormatter(
     )
   }
 }
+
+@Composable
+fun timeFormatter(
+  locale: Locale,
+  timeFormat: TimeFormat
+): TimeFormatter {
+  val lyricist = rememberStrings(currentLanguageTag = locale.language)
+
+  return remember(lyricist.strings, locale) {
+    timeFormatter(
+      strings = lyricist.strings,
+      timeFormat = timeFormat
+    )
+  }
+}
+

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/format/TimeFormatter.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/format/TimeFormatter.kt
@@ -69,7 +69,6 @@ internal fun timeFormatter(
 @Composable
 fun timeFormatter(
   locale: Locale,
-  timeFormat: TimeFormat? = null
 ): TimeFormatter {
   val lyricist = rememberStrings(currentLanguageTag = locale.language)
 
@@ -77,8 +76,8 @@ fun timeFormatter(
     timeFormatter(
       strings = lyricist.strings,
       timeFormat = when {
-        locale.language == "en"  || locale.region in listOf("US", "GB") -> timeFormat ?: TimeFormat.AM_PM
-        else -> timeFormat ?: TimeFormat.HOUR_24
+        locale.language == "en" || locale.region in listOf("US", "GB") -> TimeFormat.AM_PM
+        else -> TimeFormat.HOUR_24
       }
     )
   }

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/format/TimeFormatter.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/format/TimeFormatter.kt
@@ -69,6 +69,7 @@ internal fun timeFormatter(
 @Composable
 fun timeFormatter(
   locale: Locale,
+  timeFormat: TimeFormat? = null
 ): TimeFormatter {
   val lyricist = rememberStrings(currentLanguageTag = locale.language)
 
@@ -76,8 +77,8 @@ fun timeFormatter(
     timeFormatter(
       strings = lyricist.strings,
       timeFormat = when {
-        listOf("en", "ar").contains(locale.language)  || locale.region in listOf("US", "GB") -> TimeFormat.AM_PM
-        else -> TimeFormat.HOUR_24
+        locale.language == "en"  || locale.region in listOf("US", "GB") -> timeFormat ?: TimeFormat.AM_PM
+        else -> timeFormat ?: TimeFormat.HOUR_24
       }
     )
   }


### PR DESCRIPTION
First, thanks so much for the effort the library is great.

Second there is a visual bug when the locale is arabic but i suspect the same issue will exist for some other locales as well, the problem is:

- Currently the `WheelDateTimePicker` view support month names to be in `short` format as the month cell width will be hardcoded to a small value. 
- This works well in `english` and other locales that has shorter form of the month name.
-  Unfortunately this is not the case in `arabic` as actually there is no short form for month names ( at least common one ) so the view crops the month name as it shown in the image below.
- if the `WheelDatePicker` is used it shows the month name correctly "أغسطس" but in the `WheelDateTimePicker` it gets cropped to "أغسطـ" 
![image](https://github.com/user-attachments/assets/5c4385a1-2837-4e48-94e4-9e9b6c0e98f1)


Also `timeFormatter()` function is hardcoding the time format to `HOUR_24` in languages other than english but in arabic the `AM_PM` format works well and is desirable so modified the function parameters to take the time format from the caller and defaulting to `null` to keep compatibility with the current `API`.

The result:
![ar_enhancement](https://github.com/user-attachments/assets/f3e48251-4879-42d9-93ea-92807012d1d0)
