### PR TITLE
Fix WheelDayMonthPicker implementation

### DIFF
--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/WheelDayMonthPicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/WheelDayMonthPicker.kt
@@ -1,0 +1,53 @@
+package dev.darkokoa.datetimewheelpicker
+
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import dev.darkokoa.datetimewheelpicker.core.AdaptiveWheelDayMonthPicker
+import dev.darkokoa.datetimewheelpicker.core.SelectorProperties
+import dev.darkokoa.datetimewheelpicker.core.WheelPickerDefaults
+import dev.darkokoa.datetimewheelpicker.core.format.CjkSuffixConfig
+import dev.darkokoa.datetimewheelpicker.core.format.DateFormatter
+import dev.darkokoa.datetimewheelpicker.core.format.MonthDisplayStyle
+import dev.darkokoa.datetimewheelpicker.core.format.dateFormatter
+import kotlinx.datetime.LocalDateTime
+
+@Composable
+fun WheelDayMonthPicker(
+    modifier: Modifier = Modifier,
+    month: Int,
+    dayOfMonth: Int,
+    dateFormatter: DateFormatter = dateFormatter(
+        locale = Locale.current,
+        monthDisplayStyle = MonthDisplayStyle.SHORT,
+        cjkSuffixConfig = CjkSuffixConfig.HideAll
+    ),
+    size: DpSize = DpSize(256.dp, 128.dp),
+    rowCount: Int = 3,
+    textStyle: TextStyle = MaterialTheme.typography.titleMedium,
+    textColor: Color = LocalContentColor.current,
+    selectorProperties: SelectorProperties = WheelPickerDefaults.selectorProperties(),
+    onSnappedDateTime: (snappedDateTime: LocalDateTime) -> Unit = {}
+) {
+    AdaptiveWheelDayMonthPicker(
+        modifier = modifier,
+        startMonth = month,
+        startDayOfMonth = dayOfMonth,
+        dateFormatter = dateFormatter,
+        size = size,
+        rowCount = rowCount,
+        textStyle = textStyle,
+        textColor = textColor,
+        selectorProperties = selectorProperties,
+        onSnappedDateTime = { snappedDateTime ->
+            onSnappedDateTime(snappedDateTime.snappedLocalDateTime)
+            snappedDateTime.snappedIndex
+        }
+    )
+}

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/AdaptiveWheelDayMonthPicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/AdaptiveWheelDayMonthPicker.kt
@@ -1,0 +1,121 @@
+package dev.darkokoa.datetimewheelpicker.core
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import dev.darkokoa.datetimewheelpicker.core.format.CjkSuffixConfig
+import dev.darkokoa.datetimewheelpicker.core.format.DateFormatter
+import dev.darkokoa.datetimewheelpicker.core.format.MonthDisplayStyle
+import dev.darkokoa.datetimewheelpicker.core.format.dateFormatter
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.number
+
+@Composable
+internal fun AdaptiveWheelDayMonthPicker(
+    modifier: Modifier = Modifier,
+    startMonth: Int, // 1-12
+    startDayOfMonth: Int,
+    dateFormatter: DateFormatter = dateFormatter(
+        locale = Locale.current,
+        monthDisplayStyle = MonthDisplayStyle.SHORT,
+        cjkSuffixConfig = CjkSuffixConfig.HideAll
+    ),
+    size: DpSize = DpSize(256.dp, 128.dp),
+    rowCount: Int = 3,
+    textStyle: TextStyle = MaterialTheme.typography.titleMedium,
+    textColor: Color = LocalContentColor.current,
+    selectorProperties: SelectorProperties = WheelPickerDefaults.selectorProperties(),
+    onSnappedDateTime: (snappedDateTime: SnappedDateTime) -> Int? = { _ -> null }
+) {
+
+    var snappedDate by remember {
+        mutableStateOf(
+            LocalDate(2000, startMonth, startDayOfMonth)
+        )
+    }
+
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        if (selectorProperties.enabled().value) {
+            Surface(
+                modifier = Modifier
+                    .size(size.width, size.height / rowCount),
+                shape = selectorProperties.shape().value,
+                color = selectorProperties.color().value,
+                border = selectorProperties.border().value
+            ) {}
+        }
+        Row {
+            // Month picker
+            WheelTextPicker(
+                size = DpSize(
+                    width = size.width / 2,
+                    height = size.height
+                ),
+                texts = rememberFormattedMonths(size.width, dateFormatter).map { it.text },
+                rowCount = rowCount,
+                style = textStyle,
+                color = textColor,
+                selectorProperties = WheelPickerDefaults.selectorProperties(
+                    enabled = false
+                ),
+                startIndex = startMonth - 1,
+                onScrollFinished = { snappedIndex ->
+                    val newMonth = snappedIndex + 1
+                    val newDate = snappedDate.withMonthNumber(newMonth)
+                    snappedDate = newDate
+                    
+                    val snappedDateTime = LocalDateTime(snappedDate, kotlinx.datetime.LocalTime(0, 0))
+                    onSnappedDateTime(
+                        SnappedDateTime.Month(
+                            snappedDateTime,
+                            snappedIndex
+                        )
+                    )
+                    snappedIndex
+                }
+            )
+            
+            // Day picker
+            WheelTextPicker(
+                size = DpSize(
+                    width = size.width / 2,
+                    height = size.height
+                ),
+                texts = rememberFormattedDayOfMonths(snappedDate.month.number, snappedDate.year, dateFormatter).map { it.text },
+                rowCount = rowCount,
+                style = textStyle,
+                color = textColor,
+                selectorProperties = WheelPickerDefaults.selectorProperties(
+                    enabled = false
+                ),
+                startIndex = startDayOfMonth - 1,
+                onScrollFinished = { snappedIndex ->
+                    val newDay = snappedIndex + 1
+                    val newDate = snappedDate.withDayOfMonth(newDay)
+                    snappedDate = newDate
+                    
+                    val snappedDateTime = LocalDateTime(snappedDate, kotlinx.datetime.LocalTime(0, 0))
+                    onSnappedDateTime(
+                        SnappedDateTime.DayOfMonth(
+                            snappedDateTime,
+                            snappedIndex
+                        )
+                    )
+                    snappedIndex
+                }
+            )
+        }
+    }
+}

--- a/sample/composeApp/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/App.kt
+++ b/sample/composeApp/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/App.kt
@@ -40,6 +40,12 @@ internal fun App() = AppTheme {
       WheelDatePicker { snappedDate ->
         println(snappedDate)
       }
+      WheelDayMonthPicker(
+        month = 6,
+        dayOfMonth = 15
+      ) { snappedDateTime ->
+        println("Day-Month Picker: $snappedDateTime")
+      }
       WheelDateTimePicker { snappedDateTime ->
         println(snappedDateTime)
       }

--- a/sample/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/sample/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -13,7 +13,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-        A93A953729CC810C00F8E227 /* datetime-wheel-picker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "datetime-wheel-picker.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A93A953729CC810C00F8E227 /* datetime-wheel-picker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "datetime-wheel-picker.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A93A953A29CC810C00F8E227 /* iosApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp.swift; sourceTree = "<group>"; };
 		A93A953E29CC810D00F8E227 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A93A954129CC810D00F8E227 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -291,11 +291,12 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = 9Q5VL49SH2;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
-                    "${inherited}",
-                    "$(SRCROOT)/../../sample/composeApp/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
-                );
+					"${inherited}",
+					"$(SRCROOT)/../../sample/composeApp/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -328,11 +329,12 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = 9Q5VL49SH2;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
-                    "${inherited}",
-                    "$(SRCROOT)/../../sample/composeApp/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
-                );
+					"${inherited}",
+					"$(SRCROOT)/../../sample/composeApp/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;


### PR DESCRIPTION
- Fix parameter types: startDayOfMonth Int instead of Month
- Remove time picker component for day-month only picker
- Fix LocalDate constructor and remove undefined variables
- Create proper two-wheel picker (month + day, no year)
- Update callback signatures to match expected API
- Add WheelDayMonthPicker to sample app for testing
- Remove deprecated LocalDate constructor usage