### PR TITLE
feat: add Uzbek language support and optimize locale resolution

### DIFF
--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/CJKWheelDatePicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/CJKWheelDatePicker.kt
@@ -21,6 +21,7 @@ import dev.darkokoa.datetimewheelpicker.core.format.DateField
 import dev.darkokoa.datetimewheelpicker.core.format.DateFormatter
 import dev.darkokoa.datetimewheelpicker.core.format.MonthDisplayStyle
 import dev.darkokoa.datetimewheelpicker.core.format.dateFormatter
+import dev.darkokoa.datetimewheelpicker.core.resolveLanguageTag
 import dev.darkokoa.datetimewheelpicker.rememberStrings
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.number
@@ -45,7 +46,7 @@ internal fun CJKWheelDatePicker(
   onSnappedDate: (snappedDate: SnappedDate) -> Int? = { _ -> null }
 ) {
   val currentLocale = Locale.current
-  val strings = rememberStrings(currentLanguageTag = currentLocale.language).strings
+  val strings = rememberStrings(currentLanguageTag = currentLocale.resolveLanguageTag()).strings
 
   val itemWidth = Dp.Infinity
 

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/LocaleExtensions.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/LocaleExtensions.kt
@@ -1,8 +1,47 @@
 package dev.darkokoa.datetimewheelpicker.core
 
 import androidx.compose.ui.text.intl.Locale
+import dev.darkokoa.datetimewheelpicker.strings.EnStrings
+import dev.darkokoa.datetimewheelpicker.strings.Strings
 
 private val CJK_LANGUAGES = listOf("zh", "ja", "ko")
 
 val Locale.isCjkLanguage: Boolean
   get() = language in CJK_LANGUAGES
+
+internal fun Locale.resolveStrings(
+  stringsMap: Map<String, Strings> = dev.darkokoa.datetimewheelpicker.Strings
+): Strings = resolveStringsFromComponents(
+  script = script, language = language, stringsMap = stringsMap
+)
+
+internal fun Locale.resolveLanguageTag(
+  stringsMap: Map<String, Strings> = dev.darkokoa.datetimewheelpicker.Strings
+): String = resolveLanguageTagFromComponents(
+  script = script, language = language, stringsMap = stringsMap
+)
+
+internal fun resolveStringsFromComponents(
+  script: String,
+  language: String,
+  stringsMap: Map<String, Strings>
+): Strings {
+  if (script.isNotEmpty()) {
+    stringsMap["$language-$script"]?.let { return it }
+  }
+  stringsMap[language]?.let { return it }
+  return EnStrings
+}
+
+internal fun resolveLanguageTagFromComponents(
+  script: String,
+  language: String,
+  stringsMap: Map<String, Strings>
+): String {
+  if (script.isNotEmpty()) {
+    val langScript = "$language-$script"
+    if (langScript in stringsMap) return langScript
+  }
+  if (language in stringsMap) return language
+  return "en"
+}

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/format/DateFormatter.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/format/DateFormatter.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.text.intl.Locale
+import dev.darkokoa.datetimewheelpicker.core.resolveLanguageTag
+import dev.darkokoa.datetimewheelpicker.core.resolveStrings
 import dev.darkokoa.datetimewheelpicker.rememberStrings
 import dev.darkokoa.datetimewheelpicker.strings.EnStrings
 import dev.darkokoa.datetimewheelpicker.strings.Strings
@@ -37,7 +39,7 @@ fun dateFormatter(
   cjkSuffixConfig: CjkSuffixConfig = CjkSuffixConfig.ShowAll,
   formatYear: (Int) -> String = { it.toLocalizedNumerals() },
   formatMonth: (Month, MonthDisplayStyle) -> String = { month, style ->
-    val strings = (dev.darkokoa.datetimewheelpicker.Strings[Locale.current.language] ?: EnStrings)
+    val strings = Locale.current.resolveStrings()
     when (style) {
       MonthDisplayStyle.FULL -> month.fullString(strings)
       MonthDisplayStyle.SHORT -> month.shortString(strings)
@@ -83,7 +85,7 @@ fun dateFormatter(
   monthDisplayStyle: MonthDisplayStyle,
   cjkSuffixConfig: CjkSuffixConfig
 ): DateFormatter {
-  val lyricist = rememberStrings(currentLanguageTag = locale.language)
+  val lyricist = rememberStrings(currentLanguageTag = locale.resolveLanguageTag())
 
   return remember(lyricist.strings, locale, monthDisplayStyle, cjkSuffixConfig) {
     dateFormatter(

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/format/LocalizedNumeralsExt.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/format/LocalizedNumeralsExt.kt
@@ -1,16 +1,24 @@
 package dev.darkokoa.datetimewheelpicker.core.format
 
 import androidx.compose.ui.text.intl.Locale
-import dev.darkokoa.datetimewheelpicker.strings.EnStrings
+import dev.darkokoa.datetimewheelpicker.core.resolveStrings
 import dev.darkokoa.datetimewheelpicker.strings.Strings
 
 internal fun Int.toLocalizedNumerals(locale: Locale = Locale.current): String {
   return this.toString().toLocalizedNumerals(locale)
 }
 
+/**
+ * Converts digits in the string to the localized numerals for the current Locale.
+ *
+ * Uses [resolveStrings] to obtain the [Strings] for the given Locale,
+ * then checks whether [Strings.digit0] is a non-standard digit (i.e. != '0') to decide if conversion is needed.
+ * This automatically covers all languages that define localized digits in their Strings (e.g. ar, fa, uz-Arab),
+ * without maintaining a hardcoded language list.
+ */
 internal fun String.toLocalizedNumerals(locale: Locale = Locale.current): String {
-  return if (locale.language in arrayOf("ar", "fa")) {
-    val strings = dev.darkokoa.datetimewheelpicker.Strings[locale.language] ?: EnStrings
+  val strings = locale.resolveStrings()
+  return if (strings.digit0 != '0') {
     this.toLocalizedNumerals(strings)
   } else {
     this

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/format/TimeFormatter.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/format/TimeFormatter.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.text.intl.Locale
+import dev.darkokoa.datetimewheelpicker.core.resolveLanguageTag
+import dev.darkokoa.datetimewheelpicker.core.resolveStrings
 import dev.darkokoa.datetimewheelpicker.rememberStrings
 import dev.darkokoa.datetimewheelpicker.strings.EnStrings
 import dev.darkokoa.datetimewheelpicker.strings.Strings
@@ -34,10 +36,10 @@ fun timeFormatter(
     minute.toString().padStart(2, '0').toLocalizedNumerals()
   },
   formatAmText: () -> String = {
-    (dev.darkokoa.datetimewheelpicker.Strings[Locale.current.language] ?: EnStrings).timeAM
+    Locale.current.resolveStrings().timeAM
   },
   formatPmText: () -> String = {
-    (dev.darkokoa.datetimewheelpicker.Strings[Locale.current.language] ?: EnStrings).timePM
+    Locale.current.resolveStrings().timePM
   },
 ): TimeFormatter = TimeFormatterImpl(
   timeFormat = timeFormat,
@@ -70,7 +72,7 @@ internal fun timeFormatter(
 fun timeFormatter(
   locale: Locale,
 ): TimeFormatter {
-  val lyricist = rememberStrings(currentLanguageTag = locale.language)
+  val lyricist = rememberStrings(currentLanguageTag = locale.resolveLanguageTag())
 
   return remember(lyricist.strings, locale) {
     timeFormatter(

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/UzArabStrings.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/UzArabStrings.kt
@@ -1,0 +1,46 @@
+package dev.darkokoa.datetimewheelpicker.strings
+
+import cafe.adriel.lyricist.LyricistStrings
+
+@LyricistStrings(languageTag = "uz-Arab")
+internal val UzArabStrings = Strings(
+  monthJanuaryFull = "جنوری",
+  monthFebruaryFull = "فبروری",
+  monthMarchFull = "مارچ",
+  monthAprilFull = "اپریل",
+  monthMayFull = "می",
+  monthJuneFull = "جون",
+  monthJulyFull = "جولای",
+  monthAugustFull = "اگست",
+  monthSeptemberFull = "سپتمبر",
+  monthOctoberFull = "اکتوبر",
+  monthNovemberFull = "نومبر",
+  monthDecemberFull = "دسمبر",
+
+  monthJanuaryShort = "جنو",
+  monthFebruaryShort = "فبر",
+  monthMarchShort = "مار",
+  monthAprilShort = "اپر",
+  monthMayShort = "می",
+  monthJuneShort = "جون",
+  monthJulyShort = "جول",
+  monthAugustShort = "اگس",
+  monthSeptemberShort = "سپت",
+  monthOctoberShort = "اکت",
+  monthNovemberShort = "نوم",
+  monthDecemberShort = "دسم",
+
+  timeAM = "AM",
+  timePM = "PM",
+
+  digit0 = '۰',
+  digit1 = '۱',
+  digit2 = '۲',
+  digit3 = '۳',
+  digit4 = '۴',
+  digit5 = '۵',
+  digit6 = '۶',
+  digit7 = '۷',
+  digit8 = '۸',
+  digit9 = '۹'
+)

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/UzCyrlStrings.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/UzCyrlStrings.kt
@@ -1,0 +1,35 @@
+package dev.darkokoa.datetimewheelpicker.strings
+
+import cafe.adriel.lyricist.LyricistStrings
+
+@LyricistStrings(languageTag = "uz-Cyrl")
+internal val UzCyrlStrings = Strings(
+  monthJanuaryFull = "Январь",
+  monthFebruaryFull = "Февраль",
+  monthMarchFull = "Март",
+  monthAprilFull = "Апрель",
+  monthMayFull = "Май",
+  monthJuneFull = "Июнь",
+  monthJulyFull = "Июль",
+  monthAugustFull = "Август",
+  monthSeptemberFull = "Сентябрь",
+  monthOctoberFull = "Октябрь",
+  monthNovemberFull = "Ноябрь",
+  monthDecemberFull = "Декабрь",
+
+  monthJanuaryShort = "Янв",
+  monthFebruaryShort = "Фев",
+  monthMarchShort = "Мар",
+  monthAprilShort = "Апр",
+  monthMayShort = "Май",
+  monthJuneShort = "Июн",
+  monthJulyShort = "Июл",
+  monthAugustShort = "Авг",
+  monthSeptemberShort = "Сен",
+  monthOctoberShort = "Окт",
+  monthNovemberShort = "Ноя",
+  monthDecemberShort = "Дек",
+
+  timeAM = "ТО",
+  timePM = "ТК"
+)

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/UzStrings.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/UzStrings.kt
@@ -1,0 +1,35 @@
+package dev.darkokoa.datetimewheelpicker.strings
+
+import cafe.adriel.lyricist.LyricistStrings
+
+@LyricistStrings(languageTag = "uz")
+internal val UzStrings = Strings(
+  monthJanuaryFull = "Yanvar",
+  monthFebruaryFull = "Fevral",
+  monthMarchFull = "Mart",
+  monthAprilFull = "Aprel",
+  monthMayFull = "May",
+  monthJuneFull = "Iyun",
+  monthJulyFull = "Iyul",
+  monthAugustFull = "Avgust",
+  monthSeptemberFull = "Sentabr",
+  monthOctoberFull = "Oktabr",
+  monthNovemberFull = "Noyabr",
+  monthDecemberFull = "Dekabr",
+
+  monthJanuaryShort = "Yan",
+  monthFebruaryShort = "Fev",
+  monthMarchShort = "Mar",
+  monthAprilShort = "Apr",
+  monthMayShort = "May",
+  monthJuneShort = "Iyn",
+  monthJulyShort = "Iyl",
+  monthAugustShort = "Avg",
+  monthSeptemberShort = "Sen",
+  monthOctoberShort = "Okt",
+  monthNovemberShort = "Noy",
+  monthDecemberShort = "Dek",
+
+  timeAM = "TO",
+  timePM = "TK"
+)

--- a/datetime-wheel-picker/src/commonTest/kotlin/dev/darkokoa/datetimewheelpicker/core/LocaleResolutionTest.kt
+++ b/datetime-wheel-picker/src/commonTest/kotlin/dev/darkokoa/datetimewheelpicker/core/LocaleResolutionTest.kt
@@ -1,0 +1,97 @@
+package dev.darkokoa.datetimewheelpicker.core
+
+import dev.darkokoa.datetimewheelpicker.strings.EnStrings
+import dev.darkokoa.datetimewheelpicker.strings.Strings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class LocaleResolutionTest {
+
+  // Distinct Strings instances for identity-based assertions
+  private val fakeEn = EnStrings
+  private val fakeUz = Strings(monthJanuaryFull = "Yanvar")
+  private val fakeUzCyrl = Strings(monthJanuaryFull = "Январь")
+  private val fakeUzArab = Strings(monthJanuaryFull = "جنوری", digit0 = '۰')
+  private val fakeDe = Strings(monthJanuaryFull = "Januar")
+
+  private val stringsMap = mapOf(
+    "en" to fakeEn,
+    "uz" to fakeUz,
+    "uz-Cyrl" to fakeUzCyrl,
+    "uz-Arab" to fakeUzArab,
+    "de" to fakeDe,
+  )
+
+  // ---- resolveStringsFromComponents ----
+
+  @Test
+  fun exactScriptMatch_uzArab() {
+    val result = resolveStringsFromComponents(script = "Arab", language = "uz", stringsMap)
+    assertSame(fakeUzArab, result, "uz-Arab should resolve to UzArabStrings")
+  }
+
+  @Test
+  fun exactScriptMatch_uzCyrl() {
+    val result = resolveStringsFromComponents(script = "Cyrl", language = "uz", stringsMap)
+    assertSame(fakeUzCyrl, result, "uz-Cyrl should resolve to UzCyrlStrings")
+  }
+
+  @Test
+  fun scriptFallsBackToLanguage_uzLatn() {
+    // "uz-Latn" is NOT in the map — should fall back to "uz"
+    val result = resolveStringsFromComponents(script = "Latn", language = "uz", stringsMap)
+    assertSame(fakeUz, result, "uz-Latn should fall back to uz (Latin is the default)")
+  }
+
+  @Test
+  fun emptyScriptFallsBackToLanguage() {
+    val result = resolveStringsFromComponents(script = "", language = "uz", stringsMap)
+    assertSame(fakeUz, result, "Empty script with uz should resolve to uz")
+  }
+
+  @Test
+  fun unknownLanguageFallsBackToEn() {
+    val result = resolveStringsFromComponents(script = "", language = "xx", stringsMap)
+    assertSame(fakeEn, result, "Unknown language should fall back to en")
+  }
+
+  @Test
+  fun unknownLanguageAndScriptFallsBackToEn() {
+    val result = resolveStringsFromComponents(script = "Zzzz", language = "xx", stringsMap)
+    assertSame(fakeEn, result, "Unknown language+script should fall back to en")
+  }
+
+  @Test
+  fun existingLocaleWithoutScript_backwardCompatible() {
+    val result = resolveStringsFromComponents(script = "", language = "de", stringsMap)
+    assertSame(fakeDe, result, "Existing locale de should still resolve directly")
+  }
+
+  // ---- resolveLanguageTagFromComponents ----
+
+  @Test
+  fun languageTag_exactScriptMatch() {
+    val tag = resolveLanguageTagFromComponents(script = "Arab", language = "uz", stringsMap)
+    assertEquals("uz-Arab", tag)
+  }
+
+  @Test
+  fun languageTag_withoutScript() {
+    val tag = resolveLanguageTagFromComponents(script = "", language = "de", stringsMap)
+    assertEquals("de", tag)
+  }
+
+  @Test
+  fun languageTag_unknownFallsBackToEn() {
+    val tag = resolveLanguageTagFromComponents(script = "", language = "xx", stringsMap)
+    assertEquals("en", tag)
+  }
+
+  @Test
+  fun languageTag_unknownScriptFallsBackToLanguage() {
+    // "uz-Latn" not in map → falls back to "uz"
+    val tag = resolveLanguageTagFromComponents(script = "Latn", language = "uz", stringsMap)
+    assertEquals("uz", tag)
+  }
+}

--- a/datetime-wheel-picker/src/commonTest/kotlin/dev/darkokoa/datetimewheelpicker/core/LocaleResolutionTest.kt
+++ b/datetime-wheel-picker/src/commonTest/kotlin/dev/darkokoa/datetimewheelpicker/core/LocaleResolutionTest.kt
@@ -1,10 +1,16 @@
 package dev.darkokoa.datetimewheelpicker.core
 
+import androidx.compose.ui.text.intl.Locale
 import dev.darkokoa.datetimewheelpicker.strings.EnStrings
+import dev.darkokoa.datetimewheelpicker.strings.JaStrings
+import dev.darkokoa.datetimewheelpicker.strings.KoStrings
 import dev.darkokoa.datetimewheelpicker.strings.Strings
+import dev.darkokoa.datetimewheelpicker.strings.ZhStrings
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 class LocaleResolutionTest {
 
@@ -93,5 +99,58 @@ class LocaleResolutionTest {
     // "uz-Latn" not in map → falls back to "uz"
     val tag = resolveLanguageTagFromComponents(script = "Latn", language = "uz", stringsMap)
     assertEquals("uz", tag)
+  }
+
+  // ---- Integration with the real default Strings map ----
+  //
+  // These tests exercise the resolution against the real KSP-generated
+  // `dev.darkokoa.datetimewheelpicker.Strings` map (no `zh-Hant` / `zh-Hans`
+  // entries), locking in the documented CJK fallback behavior.
+
+  @Test
+  fun realMap_zhHantFallsBackToZh() {
+    val strings = Locale("zh-Hant").resolveStrings()
+    assertSame(ZhStrings, strings, "zh-Hant should fall back to ZhStrings (no Hant variant)")
+  }
+
+  @Test
+  fun realMap_zhHansFallsBackToZh() {
+    val strings = Locale("zh-Hans").resolveStrings()
+    assertSame(ZhStrings, strings, "zh-Hans should fall back to ZhStrings (no Hans variant)")
+  }
+
+  @Test
+  fun realMap_zhHantLanguageTag() {
+    assertEquals("zh", Locale("zh-Hant").resolveLanguageTag())
+  }
+
+  @Test
+  fun realMap_jaResolvesToJaStrings() {
+    assertSame(JaStrings, Locale("ja").resolveStrings())
+    assertEquals("ja", Locale("ja").resolveLanguageTag())
+  }
+
+  @Test
+  fun realMap_koResolvesToKoStrings() {
+    assertSame(KoStrings, Locale("ko").resolveStrings())
+    assertEquals("ko", Locale("ko").resolveLanguageTag())
+  }
+
+  // ---- isCjkLanguage ----
+
+  @Test
+  fun isCjkLanguage_trueForZhJaKo() {
+    assertTrue(Locale("zh").isCjkLanguage)
+    assertTrue(Locale("ja").isCjkLanguage)
+    assertTrue(Locale("ko").isCjkLanguage)
+    // Script-tagged Chinese still counts as CJK
+    assertTrue(Locale("zh-Hant").isCjkLanguage)
+  }
+
+  @Test
+  fun isCjkLanguage_falseForOthers() {
+    assertFalse(Locale("en").isCjkLanguage)
+    assertFalse(Locale("uz-Arab").isCjkLanguage)
+    assertFalse(Locale("ar").isCjkLanguage)
   }
 }

--- a/datetime-wheel-picker/src/commonTest/kotlin/dev/darkokoa/datetimewheelpicker/core/format/DateTimeFormatterLocalizationTest.kt
+++ b/datetime-wheel-picker/src/commonTest/kotlin/dev/darkokoa/datetimewheelpicker/core/format/DateTimeFormatterLocalizationTest.kt
@@ -1,0 +1,79 @@
+package dev.darkokoa.datetimewheelpicker.core.format
+
+import dev.darkokoa.datetimewheelpicker.strings.UzArabStrings
+import kotlinx.datetime.Month
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * End-to-end tests that exercise the public formatting path for locales that
+ * combine non-Latin month names with non-ASCII numerals (uz-Arab).
+ *
+ * These go one layer above [NumeralConversionTest] / [LocaleResolutionTest]
+ * by invoking the internal `dateFormatter(strings = ...)` / `timeFormatter(strings = ...)`
+ * overloads — the same overloads that the public `@Composable` variants ultimately delegate to.
+ */
+class DateTimeFormatterLocalizationTest {
+
+  // Extended Arabic-Indic digits (U+06F0 series) used by UzArabStrings
+  private val uzArabDigits = "۰۱۲۳۴۵۶۷۸۹"
+
+  // ---- DateFormatter (uz-Arab) ----
+
+  @Test
+  fun uzArab_fullMonthName() {
+    val formatter = dateFormatter(strings = UzArabStrings)
+    assertEquals("جنوری", formatter.formatMonth(Month.JANUARY, MonthDisplayStyle.FULL))
+    assertEquals("دسمبر", formatter.formatMonth(Month.DECEMBER, MonthDisplayStyle.FULL))
+  }
+
+  @Test
+  fun uzArab_shortMonthName() {
+    val formatter = dateFormatter(strings = UzArabStrings)
+    assertEquals("جنو", formatter.formatMonth(Month.JANUARY, MonthDisplayStyle.SHORT))
+    assertEquals("دسم", formatter.formatMonth(Month.DECEMBER, MonthDisplayStyle.SHORT))
+  }
+
+  @Test
+  fun uzArab_numericMonthUsesExtendedArabicIndicDigits() {
+    val formatter = dateFormatter(strings = UzArabStrings)
+    // Month.JANUARY.number == 1  → "۱"
+    assertEquals("۱", formatter.formatMonth(Month.JANUARY, MonthDisplayStyle.NUMERIC))
+    // Month.DECEMBER.number == 12 → "۱۲"
+    assertEquals("۱۲", formatter.formatMonth(Month.DECEMBER, MonthDisplayStyle.NUMERIC))
+  }
+
+  @Test
+  fun uzArab_yearAndDayUseExtendedArabicIndicDigits() {
+    val formatter = dateFormatter(strings = UzArabStrings)
+    assertEquals("۲۰۲۵", formatter.formatYear(2025))
+    assertEquals("۹", formatter.formatDay(9))
+    assertEquals("۳۱", formatter.formatDay(31))
+  }
+
+  @Test
+  fun uzArab_allDigitsMapped() {
+    val formatter = dateFormatter(strings = UzArabStrings)
+    val actual = (0..9).joinToString(separator = "") { formatter.formatDay(it) }
+    assertEquals(uzArabDigits, actual)
+  }
+
+  // ---- TimeFormatter (uz-Arab) ----
+
+  @Test
+  fun uzArab_hourAndMinuteUseExtendedArabicIndicDigits() {
+    val formatter = timeFormatter(strings = UzArabStrings)
+    // Hours/minutes are zero-padded to 2 characters before digit mapping
+    assertEquals("۰۹", formatter.formatHour(9))
+    assertEquals("۲۳", formatter.formatHour(23))
+    assertEquals("۰۰", formatter.formatMinute(0))
+    assertEquals("۵۹", formatter.formatMinute(59))
+  }
+
+  @Test
+  fun uzArab_amPmTextFromStrings() {
+    val formatter = timeFormatter(strings = UzArabStrings)
+    assertEquals(UzArabStrings.timeAM, formatter.formatAmText())
+    assertEquals(UzArabStrings.timePM, formatter.formatPmText())
+  }
+}

--- a/datetime-wheel-picker/src/commonTest/kotlin/dev/darkokoa/datetimewheelpicker/core/format/NumeralConversionTest.kt
+++ b/datetime-wheel-picker/src/commonTest/kotlin/dev/darkokoa/datetimewheelpicker/core/format/NumeralConversionTest.kt
@@ -1,0 +1,79 @@
+package dev.darkokoa.datetimewheelpicker.core.format
+
+import dev.darkokoa.datetimewheelpicker.strings.Strings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NumeralConversionTest {
+
+  // Default Strings — ASCII digits (digit0 = '0')
+  private val asciiStrings = Strings()
+
+  // Extended Arabic-Indic (used by uz-Arab, fa): ۰-۹ (U+06F0 - U+06F9)
+  private val extendedArabicIndicStrings = Strings(
+    digit0 = '\u06F0', digit1 = '\u06F1', digit2 = '\u06F2', digit3 = '\u06F3', digit4 = '\u06F4',
+    digit5 = '\u06F5', digit6 = '\u06F6', digit7 = '\u06F7', digit8 = '\u06F8', digit9 = '\u06F9',
+  )
+
+  // Standard Arabic-Indic (used by ar): ٠-٩ (U+0660 - U+0669)
+  private val arabicIndicStrings = Strings(
+    digit0 = '\u0660', digit1 = '\u0661', digit2 = '\u0662', digit3 = '\u0663', digit4 = '\u0664',
+    digit5 = '\u0665', digit6 = '\u0666', digit7 = '\u0667', digit8 = '\u0668', digit9 = '\u0669',
+  )
+
+  // ---- ASCII passthrough ----
+
+  @Test
+  fun asciiDigitsUnchanged_whenDigit0IsAsciiZero() {
+    assertEquals("2025", "2025".toLocalizedNumerals(asciiStrings))
+  }
+
+  @Test
+  fun asciiWithLeadingZero_unchanged() {
+    assertEquals("09", "09".toLocalizedNumerals(asciiStrings))
+  }
+
+  // ---- Extended Arabic-Indic (uz-Arab, fa) ----
+
+  @Test
+  fun extendedArabicIndic_fullYear() {
+    assertEquals("۲۰۲۵", "2025".toLocalizedNumerals(extendedArabicIndicStrings))
+  }
+
+  @Test
+  fun extendedArabicIndic_leadingZero() {
+    assertEquals("۰۹", "09".toLocalizedNumerals(extendedArabicIndicStrings))
+  }
+
+  // ---- Standard Arabic-Indic (ar) ----
+
+  @Test
+  fun standardArabicIndic_fullYear() {
+    assertEquals("٢٠٢٥", "2025".toLocalizedNumerals(arabicIndicStrings))
+  }
+
+  // ---- Mixed content ----
+
+  @Test
+  fun nonDigitCharactersUnchanged() {
+    assertEquals("Jan ۱۲", "Jan 12".toLocalizedNumerals(extendedArabicIndicStrings))
+  }
+
+  // ---- Edge cases ----
+
+  @Test
+  fun emptyStringReturnsEmpty() {
+    assertEquals("", "".toLocalizedNumerals(extendedArabicIndicStrings))
+  }
+
+  @Test
+  fun stringWithNoDigitsUnchanged() {
+    assertEquals("Hello", "Hello".toLocalizedNumerals(extendedArabicIndicStrings))
+  }
+
+  @Test
+  fun allDigits_0through9() {
+    assertEquals("۰۱۲۳۴۵۶۷۸۹", "0123456789".toLocalizedNumerals(extendedArabicIndicStrings))
+    assertEquals("٠١٢٣٤٥٦٧٨٩", "0123456789".toLocalizedNumerals(arabicIndicStrings))
+  }
+}


### PR DESCRIPTION
Added:
- Uzbek (Latin) locale strings (uz): month names, AM/PM text
- Uzbek (Cyrillic) locale strings (uz-Cyrl): month names, AM/PM text
- Uzbek (Arabic) locale strings (uz-Arab): month names, AM/PM text, and Extended Arabic-Indic digits (U+06F0 series)
- resolveStrings() / resolveLanguageTag() functions that resolve locale by language + script components, supporting multi-script languages like Uzbek (uz / uz-Cyrl / uz-Arab)

Changed:
- Optimized resolveLanguageTag/resolveStrings: removed unnecessary toLanguageTag() call and full-tag Map lookup; now resolves from language + script directly, falling back to language then "en"
- Fixed toLocalizedNumerals(locale): replaced hardcoded language check (ar, fa) with Strings.digit0-based detection, so uz-Arab numeral localization now works correctly via the public dateFormatter() / timeFormatter() path

Not included:
- No support for BCP 47 Unicode extension -u-nu-latn (number=latin); the wheel picker follows the default numeral system of the script
- No distinct zh-Hans / zh-Hant strings; Chinese falls back to zh