### PR TITLE
fix: CI Build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle
-org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 

--- a/sample/composeApp/src/jsMain/kotlin/main.kt
+++ b/sample/composeApp/src/jsMain/kotlin/main.kt
@@ -1,13 +1,12 @@
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.window.CanvasBasedWindow
+import androidx.compose.ui.window.ComposeViewport
 import dev.darkokoa.datetimewheelpicker.App
-import org.jetbrains.skiko.wasm.onWasmReady
+import kotlinx.browser.document
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
-  onWasmReady {
-    CanvasBasedWindow("datetime-wheel-picker") {
-      App()
-    }
+  val body = document.body ?: return
+  ComposeViewport(body) {
+    App()
   }
 }

--- a/sample/composeApp/src/wasmJsMain/kotlin/main.kt
+++ b/sample/composeApp/src/wasmJsMain/kotlin/main.kt
@@ -1,10 +1,12 @@
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.window.CanvasBasedWindow
+import androidx.compose.ui.window.ComposeViewport
 import dev.darkokoa.datetimewheelpicker.App
+import kotlinx.browser.document
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
-  CanvasBasedWindow("datetime-wheel-picker") {
+  val body = document.body ?: return
+  ComposeViewport(body) {
     App()
   }
 }


### PR DESCRIPTION
## ~~Summary~~
  - ~~`CanvasBasedWindow` was deprecated with ERROR level in Compose Multiplatform 1.10.0, causing `compileKotlinJs` to fail in CI~~
  - ~~Migrated `sample/composeApp/src/jsMain/kotlin/main.kt` to use `ComposeViewport` API instead~~
## ~~Test plan~~
  - ~~[x] `./gradlew :sample:composeApp:compileKotlinJs` passes locally~~
  - ~~[ ] CI `check` workflow passes~~