### PR TITLE
fix: CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
 
       - name: Run checks and build
-        run: ./gradlew check :datetime-wheel-picker:assemble :sample:composeApp:assembleDebug --stacktrace
+        run: ./gradlew check :datetime-wheel-picker:assembleDebug :sample:composeApp:assembleDebug --stacktrace
 
       - name: Upload test reports
         if: failure()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle
-org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 #Gradle
-org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.caching=true
+org.gradle.parallel=true
 org.gradle.configuration-cache=true
 
 #Kotlin

--- a/sample/composeApp/src/jsMain/kotlin/main.kt
+++ b/sample/composeApp/src/jsMain/kotlin/main.kt
@@ -1,13 +1,12 @@
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.window.CanvasBasedWindow
+import androidx.compose.ui.window.ComposeViewport
 import dev.darkokoa.datetimewheelpicker.App
-import org.jetbrains.skiko.wasm.onWasmReady
+import kotlinx.browser.document
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
-  onWasmReady {
-    CanvasBasedWindow("datetime-wheel-picker") {
-      App()
-    }
+  val body = document.body ?: return
+  ComposeViewport(body) {
+    App()
   }
 }

--- a/sample/composeApp/src/wasmJsMain/kotlin/main.kt
+++ b/sample/composeApp/src/wasmJsMain/kotlin/main.kt
@@ -1,10 +1,12 @@
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.window.CanvasBasedWindow
+import androidx.compose.ui.window.ComposeViewport
 import dev.darkokoa.datetimewheelpicker.App
+import kotlinx.browser.document
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
-  CanvasBasedWindow("datetime-wheel-picker") {
+  val body = document.body ?: return
+  ComposeViewport(body) {
     App()
   }
 }


### PR DESCRIPTION
## Summary

Fix CI build failures caused by deprecated APIs and OOM during Kotlin/Native iOS framework linking.

## Changes

### JS/WasmJs sample migration
- Migrate JS sample from deprecated `CanvasBasedWindow` to `ComposeViewport`
- Migrate WasmJs sample from deprecated `CanvasBasedWindow` to `ComposeViewport`

### CI OOM fix
- Change `:datetime-wheel-picker:assemble` to `:datetime-wheel-picker:assembleDebug` in CI workflow
- This avoids triggering `linkReleaseFrameworkIosArm64` which causes Java heap space OOM on `macos-latest` (7GB RAM)
- Reference: both [haze](https://github.com/chrisbanes/haze) and [multiplatform-markdown-renderer](https://github.com/mikepenz/multiplatform-markdown-renderer) use the same strategy — only build Debug variants in CI to avoid K/N linking memory costs
- Release framework linking still happens during `deploy` job (publish to Maven Central) which has sufficient memory

### Other
- Enable `org.gradle.parallel=true` in `gradle.properties`