### PR TITLE
Upgrade AGP to 9.2.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
 
       - name: Run checks and build
-        run: ./gradlew check :datetime-wheel-picker:assembleDebug :sample:composeApp:assembleDebug --stacktrace
+        run: ./gradlew check :datetime-wheel-picker:assembleAndroidMain :sample:composeApp:assembleAndroidMain :sample:androidApp:assembleDebug --stacktrace
 
       - name: Upload test reports
         if: failure()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
   alias(libs.plugins.compose).apply(false)
   alias(libs.plugins.compose.compiler).apply(false)
   alias(libs.plugins.android.application).apply(false)
+  alias(libs.plugins.android.kotlin.multiplatform.library).apply(false)
   alias(libs.plugins.android.library).apply(false)
   alias(libs.plugins.maven.publish).apply(false)
   alias(libs.plugins.ksp).apply(false)

--- a/datetime-wheel-picker/build.gradle.kts
+++ b/datetime-wheel-picker/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
   alias(libs.plugins.multiplatform)
   alias(libs.plugins.compose)
   alias(libs.plugins.compose.compiler)
-  alias(libs.plugins.android.library)
+  alias(libs.plugins.android.kotlin.multiplatform.library)
   alias(libs.plugins.maven.publish)
   alias(libs.plugins.ksp)
 }
@@ -13,16 +13,16 @@ plugins {
 kotlin {
   applyDefaultHierarchyTemplate()
 
-  androidTarget {
-    publishLibraryVariants("release")
+  android {
+    namespace = "dev.darkokoa.datetimewheelpicker"
+    compileSdk = 36
+    minSdk = 21
 
-    compilations.all {
-      compileTaskProvider.configure {
-        compilerOptions {
-          jvmTarget.set(JvmTarget.JVM_17)
-        }
-      }
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_17)
     }
+
+    withHostTest {}
   }
 
   jvm {
@@ -124,24 +124,6 @@ kotlin.sourceSets.commonMain {
 ksp {
   arg("lyricist.internalVisibility", "true")
   arg("lyricist.packageName", "dev.darkokoa.datetimewheelpicker")
-}
-
-android {
-  namespace = "dev.darkokoa.datetimewheelpicker"
-  compileSdk = 36
-
-  defaultConfig {
-    minSdk = 21
-  }
-  sourceSets["main"].apply {
-    manifest.srcFile("src/androidMain/AndroidManifest.xml")
-    res.srcDirs("src/androidMain/resources")
-    resources.srcDirs("src/commonMain/resources")
-  }
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
 }
 
 mavenPublishing {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 kotlin = "2.3.21"
 compose = "1.11.0"
-agp = "8.13.2"
+agp = "9.2.1"
 androidx-activityCompose = "1.13.0"
 kotlinx-datetime = "0.8.0"
 ksp = "2.3.8"
@@ -22,6 +22,7 @@ multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotl
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 android-application = { id = "com.android.application", version.ref = "agp" }
+android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }

--- a/sample/androidApp/build.gradle.kts
+++ b/sample/androidApp/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.compose.compiler)
+}
+
+android {
+  namespace = "dev.darkokoa.datetimewheelpicker.androidapp"
+  compileSdk = 36
+
+  defaultConfig {
+    applicationId = "dev.darkokoa.datetimewheelpicker.androidApp"
+    minSdk = 24
+    targetSdk = 36
+    versionCode = 1
+    versionName = "1.0.0"
+  }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+}
+
+dependencies {
+  implementation(project(":sample:composeApp"))
+  implementation(libs.androidx.activityCompose)
+}

--- a/sample/androidApp/src/main/AndroidManifest.xml
+++ b/sample/androidApp/src/main/AndroidManifest.xml
@@ -2,19 +2,20 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:name=".AndroidApp"
+        android:name="dev.darkokoa.datetimewheelpicker.AndroidApp"
         android:icon="@android:drawable/ic_menu_compass"
         android:label="datetime-wheel-picker"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.NoActionBar">
         <activity
-            android:name=".AppActivity"
+            android:name="dev.darkokoa.datetimewheelpicker.AppActivity"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
+            android:exported="true"
             android:launchMode="singleInstance"
-            android:windowSoftInputMode="adjustPan"
-            android:exported="true">
+            android:windowSoftInputMode="adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/sample/androidApp/src/main/kotlin/dev/darkokoa/datetimewheelpicker/App.android.kt
+++ b/sample/androidApp/src/main/kotlin/dev/darkokoa/datetimewheelpicker/App.android.kt
@@ -1,8 +1,6 @@
 package dev.darkokoa.datetimewheelpicker
 
 import android.app.Application
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent

--- a/sample/composeApp/build.gradle.kts
+++ b/sample/composeApp/build.gradle.kts
@@ -6,17 +6,17 @@ plugins {
   alias(libs.plugins.multiplatform)
   alias(libs.plugins.compose)
   alias(libs.plugins.compose.compiler)
-  alias(libs.plugins.android.application)
+  alias(libs.plugins.android.kotlin.multiplatform.library)
 }
 
 kotlin {
-  androidTarget {
-    compilations.all {
-      compileTaskProvider.configure {
-        compilerOptions {
-          jvmTarget.set(JvmTarget.JVM_17)
-        }
-      }
+  android {
+    namespace = "dev.darkokoa.datetimewheelpicker.sample"
+    compileSdk = 36
+    minSdk = 24
+
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_17)
     }
   }
 
@@ -67,7 +67,6 @@ kotlin {
     }
 
     androidMain.dependencies {
-      implementation(libs.androidx.activityCompose)
     }
 
     jvmMain.dependencies {
@@ -85,29 +84,6 @@ kotlin {
     iosMain.dependencies {
     }
 
-  }
-}
-
-android {
-  namespace = "dev.darkokoa.datetimewheelpicker"
-  compileSdk = 36
-
-  defaultConfig {
-    minSdk = 24
-    targetSdk = 36
-
-    applicationId = "dev.darkokoa.datetimewheelpicker.androidApp"
-    versionCode = 1
-    versionName = "1.0.0"
-  }
-  sourceSets["main"].apply {
-    manifest.srcFile("src/androidMain/AndroidManifest.xml")
-    res.srcDirs("src/androidMain/resources")
-    resources.srcDirs("src/commonMain/resources")
-  }
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
   }
 }
 

--- a/sample/composeApp/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/App.kt
+++ b/sample/composeApp/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/App.kt
@@ -33,7 +33,7 @@ import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
 
 @Composable
-internal fun App() = AppTheme {
+fun App() = AppTheme {
   Surface(
     modifier = Modifier.fillMaxSize().windowInsetsPadding(WindowInsets.safeDrawing),
     color = MaterialTheme.colorScheme.background

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 rootProject.name = "datetime-wheel-picker"
+include(":sample:androidApp")
 include(":sample:composeApp")
 include(":datetime-wheel-picker")
 


### PR DESCRIPTION
## Summary
Upgrade Android Gradle Plugin from 8.13.2 to 9.2.1 and migrate Android KMP modules to the AGP 9-compatible plugin/task model.

## Changes
  - Bump AGP to 9.2.1
  - Add com.android.kotlin.multiplatform.library plugin to the version catalog
  - Migrate KMP Android library modules from com.android.library / com.android.application to com.android.kotlin.multiplatform.library
  - Move the sample Android application into a dedicated :sample:androidApp module
  - Keep :sample:composeApp as the shared Compose Multiplatform library module
  - Enable Android host tests for the library KMP target
  - Update GitHub Actions build tasks from old Android variant tasks to AGP 9 KMP-compatible tasks
  - Make the sample App() composable public so the Android app module can launch it