### PR TITLE
feat(i18n): add Czech, Danish, Greek, Finnish, Norwegian, Romanian, Swedish

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -30,8 +30,8 @@
 - **Script-aware locale matching**: A locale is matched first by its `language`+`script` subtags, then by `language` alone, and finally falls back to English. Examples: `uz-Arab` → `uz-Arab` (direct script match), `uz-Latn` → `uz` (script not bundled, base language used), `zh-Hant` → `zh` (same).
 - **Limitations**: BCP 47 `-u-*` Unicode extension subtags (e.g. `-u-nu-*` numbering system, `-u-ca-*` calendar) are ignored — only the `language` and `script` subtags influence resolution.
 
-**Currently Supported Languages (23):**
-Arabic (العربية), Bengali (বাংলা), Chinese (中文), Dutch (Nederlands), English, French (Français), German (Deutsch), Hebrew (עברית), Hindi (हिन्दी), Indonesian (Bahasa Indonesia), Italian (Italiano), Japanese (日本語), Korean (한국어), Persian (فارسی), Polish (Polski), Portuguese (Português), Russian (Русский), Spanish (Español), Thai (ไทย), Turkish (Türkçe), Ukrainian (Українська), Uzbek (Oʻzbekcha / Ўзбекча / اۉزبېکچه — `uz`, `uz-Cyrl`, `uz-Arab`), Vietnamese (Tiếng Việt)
+**Currently Supported Languages (30):**
+Arabic (العربية), Bengali (বাংলা), Chinese (中文), Czech (Čeština), Danish (Dansk), Dutch (Nederlands), English, Finnish (Suomi), French (Français), German (Deutsch), Greek (Ελληνικά), Hebrew (עברית), Hindi (हिन्दी), Indonesian (Bahasa Indonesia), Italian (Italiano), Japanese (日本語), Korean (한국어), Norwegian (Norsk — `nb`, `no`), Persian (فارسی), Polish (Polski), Portuguese (Português), Romanian (Română), Russian (Русский), Spanish (Español), Swedish (Svenska), Thai (ไทย), Turkish (Türkçe), Ukrainian (Українська), Uzbek (Oʻzbekcha / Ўзбекча / اۉزبېکچه — `uz`, `uz-Cyrl`, `uz-Arab`), Vietnamese (Tiếng Việt)
 
 > **Contributions welcome**: If you find any translation errors or want to add support for a new language, please [open an issue](../../issues) or submit a pull request.
 

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/CsStrings.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/CsStrings.kt
@@ -1,0 +1,32 @@
+package dev.darkokoa.datetimewheelpicker.strings
+
+import cafe.adriel.lyricist.LyricistStrings
+
+@LyricistStrings(languageTag = "cs")
+internal val CsStrings = Strings(
+  monthJanuaryFull = "ledna",
+  monthFebruaryFull = "února",
+  monthMarchFull = "března",
+  monthAprilFull = "dubna",
+  monthMayFull = "května",
+  monthJuneFull = "června",
+  monthJulyFull = "července",
+  monthAugustFull = "srpna",
+  monthSeptemberFull = "září",
+  monthOctoberFull = "října",
+  monthNovemberFull = "listopadu",
+  monthDecemberFull = "prosince",
+
+  monthJanuaryShort = "led",
+  monthFebruaryShort = "úno",
+  monthMarchShort = "bře",
+  monthAprilShort = "dub",
+  monthMayShort = "kvě",
+  monthJuneShort = "čvn",
+  monthJulyShort = "čvc",
+  monthAugustShort = "srp",
+  monthSeptemberShort = "zář",
+  monthOctoberShort = "říj",
+  monthNovemberShort = "lis",
+  monthDecemberShort = "pro",
+)

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/DaStrings.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/DaStrings.kt
@@ -1,0 +1,32 @@
+package dev.darkokoa.datetimewheelpicker.strings
+
+import cafe.adriel.lyricist.LyricistStrings
+
+@LyricistStrings(languageTag = "da")
+internal val DaStrings = Strings(
+  monthJanuaryFull = "januar",
+  monthFebruaryFull = "februar",
+  monthMarchFull = "marts",
+  monthAprilFull = "april",
+  monthMayFull = "maj",
+  monthJuneFull = "juni",
+  monthJulyFull = "juli",
+  monthAugustFull = "august",
+  monthSeptemberFull = "september",
+  monthOctoberFull = "oktober",
+  monthNovemberFull = "november",
+  monthDecemberFull = "december",
+
+  monthJanuaryShort = "jan.",
+  monthFebruaryShort = "feb.",
+  monthMarchShort = "mar.",
+  monthAprilShort = "apr.",
+  monthMayShort = "maj",
+  monthJuneShort = "jun.",
+  monthJulyShort = "jul.",
+  monthAugustShort = "aug.",
+  monthSeptemberShort = "sep.",
+  monthOctoberShort = "okt.",
+  monthNovemberShort = "nov.",
+  monthDecemberShort = "dec.",
+)

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/ElStrings.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/ElStrings.kt
@@ -1,0 +1,32 @@
+package dev.darkokoa.datetimewheelpicker.strings
+
+import cafe.adriel.lyricist.LyricistStrings
+
+@LyricistStrings(languageTag = "el")
+internal val ElStrings = Strings(
+  monthJanuaryFull = "Ιανουαρίου",
+  monthFebruaryFull = "Φεβρουαρίου",
+  monthMarchFull = "Μαρτίου",
+  monthAprilFull = "Απριλίου",
+  monthMayFull = "Μαΐου",
+  monthJuneFull = "Ιουνίου",
+  monthJulyFull = "Ιουλίου",
+  monthAugustFull = "Αυγούστου",
+  monthSeptemberFull = "Σεπτεμβρίου",
+  monthOctoberFull = "Οκτωβρίου",
+  monthNovemberFull = "Νοεμβρίου",
+  monthDecemberFull = "Δεκεμβρίου",
+
+  monthJanuaryShort = "Ιαν",
+  monthFebruaryShort = "Φεβ",
+  monthMarchShort = "Μαρ",
+  monthAprilShort = "Απρ",
+  monthMayShort = "Μαΐ",
+  monthJuneShort = "Ιουν",
+  monthJulyShort = "Ιουλ",
+  monthAugustShort = "Αυγ",
+  monthSeptemberShort = "Σεπ",
+  monthOctoberShort = "Οκτ",
+  monthNovemberShort = "Νοε",
+  monthDecemberShort = "Δεκ",
+)

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/FiStrings.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/FiStrings.kt
@@ -1,0 +1,32 @@
+package dev.darkokoa.datetimewheelpicker.strings
+
+import cafe.adriel.lyricist.LyricistStrings
+
+@LyricistStrings(languageTag = "fi")
+internal val FiStrings = Strings(
+  monthJanuaryFull = "tammikuuta",
+  monthFebruaryFull = "helmikuuta",
+  monthMarchFull = "maaliskuuta",
+  monthAprilFull = "huhtikuuta",
+  monthMayFull = "toukokuuta",
+  monthJuneFull = "kesäkuuta",
+  monthJulyFull = "heinäkuuta",
+  monthAugustFull = "elokuuta",
+  monthSeptemberFull = "syyskuuta",
+  monthOctoberFull = "lokakuuta",
+  monthNovemberFull = "marraskuuta",
+  monthDecemberFull = "joulukuuta",
+
+  monthJanuaryShort = "tammik.",
+  monthFebruaryShort = "helmik.",
+  monthMarchShort = "maalisk.",
+  monthAprilShort = "huhtik.",
+  monthMayShort = "toukok.",
+  monthJuneShort = "kesäk.",
+  monthJulyShort = "heinäk.",
+  monthAugustShort = "elok.",
+  monthSeptemberShort = "syysk.",
+  monthOctoberShort = "lokak.",
+  monthNovemberShort = "marrask.",
+  monthDecemberShort = "jouluk.",
+)

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/NbStrings.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/NbStrings.kt
@@ -1,0 +1,32 @@
+package dev.darkokoa.datetimewheelpicker.strings
+
+import cafe.adriel.lyricist.LyricistStrings
+
+@LyricistStrings(languageTag = "nb")
+internal val NbStrings = Strings(
+  monthJanuaryFull = "januar",
+  monthFebruaryFull = "februar",
+  monthMarchFull = "mars",
+  monthAprilFull = "april",
+  monthMayFull = "mai",
+  monthJuneFull = "juni",
+  monthJulyFull = "juli",
+  monthAugustFull = "august",
+  monthSeptemberFull = "september",
+  monthOctoberFull = "oktober",
+  monthNovemberFull = "november",
+  monthDecemberFull = "desember",
+
+  monthJanuaryShort = "jan.",
+  monthFebruaryShort = "feb.",
+  monthMarchShort = "mar.",
+  monthAprilShort = "apr.",
+  monthMayShort = "mai",
+  monthJuneShort = "jun.",
+  monthJulyShort = "jul.",
+  monthAugustShort = "aug.",
+  monthSeptemberShort = "sep.",
+  monthOctoberShort = "okt.",
+  monthNovemberShort = "nov.",
+  monthDecemberShort = "des.",
+)

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/NoStrings.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/NoStrings.kt
@@ -3,30 +3,4 @@ package dev.darkokoa.datetimewheelpicker.strings
 import cafe.adriel.lyricist.LyricistStrings
 
 @LyricistStrings(languageTag = "no")
-internal val NoStrings = Strings(
-  monthJanuaryFull = "januar",
-  monthFebruaryFull = "februar",
-  monthMarchFull = "mars",
-  monthAprilFull = "april",
-  monthMayFull = "mai",
-  monthJuneFull = "juni",
-  monthJulyFull = "juli",
-  monthAugustFull = "august",
-  monthSeptemberFull = "september",
-  monthOctoberFull = "oktober",
-  monthNovemberFull = "november",
-  monthDecemberFull = "desember",
-
-  monthJanuaryShort = "jan.",
-  monthFebruaryShort = "feb.",
-  monthMarchShort = "mar.",
-  monthAprilShort = "apr.",
-  monthMayShort = "mai",
-  monthJuneShort = "jun.",
-  monthJulyShort = "jul.",
-  monthAugustShort = "aug.",
-  monthSeptemberShort = "sep.",
-  monthOctoberShort = "okt.",
-  monthNovemberShort = "nov.",
-  monthDecemberShort = "des.",
-)
+internal val NoStrings = NbStrings

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/NoStrings.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/NoStrings.kt
@@ -1,0 +1,32 @@
+package dev.darkokoa.datetimewheelpicker.strings
+
+import cafe.adriel.lyricist.LyricistStrings
+
+@LyricistStrings(languageTag = "no")
+internal val NoStrings = Strings(
+  monthJanuaryFull = "januar",
+  monthFebruaryFull = "februar",
+  monthMarchFull = "mars",
+  monthAprilFull = "april",
+  monthMayFull = "mai",
+  monthJuneFull = "juni",
+  monthJulyFull = "juli",
+  monthAugustFull = "august",
+  monthSeptemberFull = "september",
+  monthOctoberFull = "oktober",
+  monthNovemberFull = "november",
+  monthDecemberFull = "desember",
+
+  monthJanuaryShort = "jan.",
+  monthFebruaryShort = "feb.",
+  monthMarchShort = "mar.",
+  monthAprilShort = "apr.",
+  monthMayShort = "mai",
+  monthJuneShort = "jun.",
+  monthJulyShort = "jul.",
+  monthAugustShort = "aug.",
+  monthSeptemberShort = "sep.",
+  monthOctoberShort = "okt.",
+  monthNovemberShort = "nov.",
+  monthDecemberShort = "des.",
+)

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/RoStrings.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/RoStrings.kt
@@ -1,0 +1,32 @@
+package dev.darkokoa.datetimewheelpicker.strings
+
+import cafe.adriel.lyricist.LyricistStrings
+
+@LyricistStrings(languageTag = "ro")
+internal val RoStrings = Strings(
+  monthJanuaryFull = "ianuarie",
+  monthFebruaryFull = "februarie",
+  monthMarchFull = "martie",
+  monthAprilFull = "aprilie",
+  monthMayFull = "mai",
+  monthJuneFull = "iunie",
+  monthJulyFull = "iulie",
+  monthAugustFull = "august",
+  monthSeptemberFull = "septembrie",
+  monthOctoberFull = "octombrie",
+  monthNovemberFull = "noiembrie",
+  monthDecemberFull = "decembrie",
+
+  monthJanuaryShort = "ian.",
+  monthFebruaryShort = "feb.",
+  monthMarchShort = "mar.",
+  monthAprilShort = "apr.",
+  monthMayShort = "mai",
+  monthJuneShort = "iun.",
+  monthJulyShort = "iul.",
+  monthAugustShort = "aug.",
+  monthSeptemberShort = "sept.",
+  monthOctoberShort = "oct.",
+  monthNovemberShort = "nov.",
+  monthDecemberShort = "dec.",
+)

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/SvStrings.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/strings/SvStrings.kt
@@ -1,0 +1,32 @@
+package dev.darkokoa.datetimewheelpicker.strings
+
+import cafe.adriel.lyricist.LyricistStrings
+
+@LyricistStrings(languageTag = "sv")
+internal val SvStrings = Strings(
+  monthJanuaryFull = "januari",
+  monthFebruaryFull = "februari",
+  monthMarchFull = "mars",
+  monthAprilFull = "april",
+  monthMayFull = "maj",
+  monthJuneFull = "juni",
+  monthJulyFull = "juli",
+  monthAugustFull = "augusti",
+  monthSeptemberFull = "september",
+  monthOctoberFull = "oktober",
+  monthNovemberFull = "november",
+  monthDecemberFull = "december",
+
+  monthJanuaryShort = "jan.",
+  monthFebruaryShort = "feb.",
+  monthMarchShort = "mars",
+  monthAprilShort = "apr.",
+  monthMayShort = "maj",
+  monthJuneShort = "juni",
+  monthJulyShort = "juli",
+  monthAugustShort = "aug.",
+  monthSeptemberShort = "sep.",
+  monthOctoberShort = "okt.",
+  monthNovemberShort = "nov.",
+  monthDecemberShort = "dec.",
+)

--- a/datetime-wheel-picker/src/commonTest/kotlin/dev/darkokoa/datetimewheelpicker/core/LocaleResolutionTest.kt
+++ b/datetime-wheel-picker/src/commonTest/kotlin/dev/darkokoa/datetimewheelpicker/core/LocaleResolutionTest.kt
@@ -180,9 +180,12 @@ class LocaleResolutionTest {
   }
 
   @Test
-  fun realMap_noResolvesToNoStrings() {
-    assertSame(NoStrings, Locale("no").resolveStrings())
-    assertEquals("no", Locale("no").resolveLanguageTag())
+  fun realMap_noResolvesToNorwegianStrings() {
+    assertSame(NbStrings, Locale("no").resolveStrings())
+    assertTrue(
+      Locale("no").resolveLanguageTag() in setOf("no", "nb"),
+      "Norwegian legacy tag should resolve to \"no\" or (ICU-normalised) \"nb\""
+    )
   }
 
   @Test

--- a/datetime-wheel-picker/src/commonTest/kotlin/dev/darkokoa/datetimewheelpicker/core/LocaleResolutionTest.kt
+++ b/datetime-wheel-picker/src/commonTest/kotlin/dev/darkokoa/datetimewheelpicker/core/LocaleResolutionTest.kt
@@ -1,10 +1,18 @@
 package dev.darkokoa.datetimewheelpicker.core
 
 import androidx.compose.ui.text.intl.Locale
+import dev.darkokoa.datetimewheelpicker.strings.CsStrings
+import dev.darkokoa.datetimewheelpicker.strings.DaStrings
+import dev.darkokoa.datetimewheelpicker.strings.ElStrings
 import dev.darkokoa.datetimewheelpicker.strings.EnStrings
+import dev.darkokoa.datetimewheelpicker.strings.FiStrings
 import dev.darkokoa.datetimewheelpicker.strings.JaStrings
 import dev.darkokoa.datetimewheelpicker.strings.KoStrings
+import dev.darkokoa.datetimewheelpicker.strings.NbStrings
+import dev.darkokoa.datetimewheelpicker.strings.NoStrings
+import dev.darkokoa.datetimewheelpicker.strings.RoStrings
 import dev.darkokoa.datetimewheelpicker.strings.Strings
+import dev.darkokoa.datetimewheelpicker.strings.SvStrings
 import dev.darkokoa.datetimewheelpicker.strings.ZhStrings
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -134,6 +142,59 @@ class LocaleResolutionTest {
   fun realMap_koResolvesToKoStrings() {
     assertSame(KoStrings, Locale("ko").resolveStrings())
     assertEquals("ko", Locale("ko").resolveLanguageTag())
+  }
+
+  // ---- Newly added European locales ----
+  //
+  // Each should resolve to its own bundled Strings (not fall back to EnStrings)
+  // and report its own language tag.
+
+  @Test
+  fun realMap_csResolvesToCsStrings() {
+    assertSame(CsStrings, Locale("cs").resolveStrings())
+    assertEquals("cs", Locale("cs").resolveLanguageTag())
+  }
+
+  @Test
+  fun realMap_daResolvesToDaStrings() {
+    assertSame(DaStrings, Locale("da").resolveStrings())
+    assertEquals("da", Locale("da").resolveLanguageTag())
+  }
+
+  @Test
+  fun realMap_elResolvesToElStrings() {
+    assertSame(ElStrings, Locale("el").resolveStrings())
+    assertEquals("el", Locale("el").resolveLanguageTag())
+  }
+
+  @Test
+  fun realMap_fiResolvesToFiStrings() {
+    assertSame(FiStrings, Locale("fi").resolveStrings())
+    assertEquals("fi", Locale("fi").resolveLanguageTag())
+  }
+
+  @Test
+  fun realMap_nbResolvesToNbStrings() {
+    assertSame(NbStrings, Locale("nb").resolveStrings())
+    assertEquals("nb", Locale("nb").resolveLanguageTag())
+  }
+
+  @Test
+  fun realMap_noResolvesToNoStrings() {
+    assertSame(NoStrings, Locale("no").resolveStrings())
+    assertEquals("no", Locale("no").resolveLanguageTag())
+  }
+
+  @Test
+  fun realMap_roResolvesToRoStrings() {
+    assertSame(RoStrings, Locale("ro").resolveStrings())
+    assertEquals("ro", Locale("ro").resolveLanguageTag())
+  }
+
+  @Test
+  fun realMap_svResolvesToSvStrings() {
+    assertSame(SvStrings, Locale("sv").resolveStrings())
+    assertEquals("sv", Locale("sv").resolveLanguageTag())
   }
 
   // ---- isCjkLanguage ----


### PR DESCRIPTION
## What

Adds bundled month-name localization for **7 additional European locales** so the wheel pickers show correctly localized month names instead of falling back to English:

| locale | language |
|---|---|
| `cs` | Czech (Čeština) |
| `da` | Danish (Dansk) |
| `el` | Greek (Ελληνικά) |
| `fi` | Finnish (Suomi) |
| `nb` / `no` | Norwegian Bokmål (Norsk) |
| `ro` | Romanian (Română) |
| `sv` | Swedish (Svenska) |

Supported-language count goes **23 → 30**.

## How

Each language is a single new `*Strings.kt` under `strings/`, annotated with `@LyricistStrings(languageTag = "…")`, following the existing `PlStrings.kt` / `ItStrings.kt` pattern. The Lyricist KSP processor picks them up automatically — no changes to the resolution logic or any registry were needed. All 7 are non-CJK European locales, so they fall into the existing `DateOrder.DMY` default with no `DateOrder` change.

### Notes on the translations
- **Month names follow CLDR.** For the **inflected** languages (Czech, Greek, Finnish) I used the *date / standalone* form consistent with the existing Polish (`stycznia`) and Russian (`января`) entries — e.g. Czech `ledna`, Greek `Ιανουαρίου`, Finnish `tammikuuta`. Happy to switch to nominative forms (`leden` / `Ιανουάριος` / `tammikuu`) if you'd prefer that for a standalone picker column — just let me know.
- **Norwegian is registered under both `nb` and `no`** (identical data). `Locale.language` normalization between Bokmål's modern (`nb`) and legacy (`no`) tags differs across platforms, so registering both guarantees resolution regardless. This mirrors the existing multi-tag precedent for Uzbek.
- AM/PM and digits are left at the defaults for all 7 (none use a non-Latin numeral system).

## Tests

Added `LocaleResolutionTest` cases asserting each new tag resolves to its own `Strings` instance (and the right language tag), mirroring `realMap_jaResolvesToJaStrings`. Verified locally:

```
./gradlew :datetime-wheel-picker:jvmTest   # BUILD SUCCESSFUL — 26 tests, 0 failures
```

The KSP-generated `Strings` map now contains all 8 new tags.

## Docs

Updated the "Currently Supported Languages" list in `README.MD` (count + alphabetical entries).