### PR TITLE
perf(core): optimize WheelPicker scroll rendering and reject invalid sizing inputs

### DIFF
--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isFinite
 import kotlin.math.abs
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -36,7 +37,9 @@ internal fun WheelPicker(
   content: @Composable LazyItemScope.(index: Int) -> Unit,
 ) {
   require(rowCount > 0) { "rowCount must be positive, was $rowCount" }
-  require(size.height > 0.dp) { "size.height must be positive, was ${size.height}" }
+  require(size.height.isFinite && size.height > 0.dp) {
+    "size.height must be finite and positive, was ${size.height}"
+  }
   val lazyListState = rememberLazyListState(startIndex)
   val flingBehavior = rememberSnapFlingBehavior(lazyListState)
   val latestOnScrollChanged by rememberUpdatedState(onScrollChanged)

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
@@ -13,10 +13,10 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import kotlin.math.abs
@@ -39,6 +39,10 @@ internal fun WheelPicker(
   val flingBehavior = rememberSnapFlingBehavior(lazyListState)
   val latestOnScrollChanged by rememberUpdatedState(onScrollChanged)
   val latestOnScrollFinished by rememberUpdatedState(onScrollFinished)
+  val density = LocalDensity.current
+  val singleViewPortHeightPx = remember(size, rowCount, density) {
+    with(density) { size.height.toPx() } / rowCount
+  }
 
   LaunchedEffect(lazyListState, count) {
     snapshotFlow { calculateSnappedItemIndex(lazyListState) }
@@ -77,19 +81,19 @@ internal fun WheelPicker(
       flingBehavior = flingBehavior
     ) {
       items(count) { index ->
-        val (newAlpha, newRotationX) = calculateAnimatedAlphaAndRotationX(
-          lazyListState = lazyListState,
-          index = index,
-          rowCount = rowCount
-        )
-
         Box(
           modifier = Modifier
             .height(size.height / rowCount)
             .width(size.width)
-            .alpha(newAlpha)
             .graphicsLayer {
-              rotationX = newRotationX
+              val centerIndex = lazyListState.firstVisibleItemIndex
+              val centerIndexOffset = lazyListState.firstVisibleItemScrollOffset
+              val distanceToCenterIndex = index - centerIndex
+              val distanceToIndexSnap = distanceToCenterIndex * singleViewPortHeightPx - centerIndexOffset
+              val distanceToIndexSnapAbs = abs(distanceToIndexSnap)
+              alpha = if (distanceToIndexSnapAbs in 0f..singleViewPortHeightPx)
+                1.2f - (distanceToIndexSnapAbs / singleViewPortHeightPx) else 0.2f
+              rotationX = (-20f * (distanceToIndexSnap / singleViewPortHeightPx)).takeUnless { it.isNaN() } ?: 0f
             },
           contentAlignment = Alignment.Center
         ) {
@@ -111,36 +115,6 @@ private fun calculateSnappedItemIndex(lazyListState: LazyListState): Int {
   } else {
     currentItemIndex
   }
-}
-
-@Composable
-private fun calculateAnimatedAlphaAndRotationX(
-  lazyListState: LazyListState,
-  index: Int,
-  rowCount: Int
-): Pair<Float, Float> {
-
-  val layoutInfo = remember { derivedStateOf { lazyListState.layoutInfo } }.value
-  val viewPortHeight = layoutInfo.viewportSize.height.toFloat()
-  val singleViewPortHeight = viewPortHeight / rowCount
-
-  val centerIndex = remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }.value
-  val centerIndexOffset = remember { derivedStateOf { lazyListState.firstVisibleItemScrollOffset } }.value
-
-  val distanceToCenterIndex = index - centerIndex
-
-  val distanceToIndexSnap = distanceToCenterIndex * singleViewPortHeight.toInt() - centerIndexOffset
-  val distanceToIndexSnapAbs = abs(distanceToIndexSnap)
-
-  val animatedAlpha = if (abs(distanceToIndexSnap) in 0..singleViewPortHeight.toInt()) {
-    1.2f - (distanceToIndexSnapAbs / singleViewPortHeight)
-  } else {
-    0.2f
-  }
-
-  val animatedRotationX = (-20 * (distanceToIndexSnap / singleViewPortHeight)).takeUnless { it.isNaN() } ?: 0f
-
-  return animatedAlpha to animatedRotationX
 }
 
 object WheelPickerDefaults {
@@ -200,4 +174,3 @@ internal class DefaultSelectorProperties(
     return rememberUpdatedState(border)
   }
 }
-

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
@@ -35,6 +35,8 @@ internal fun WheelPicker(
   onScrollFinished: (snappedIndex: Int) -> Int? = { null },
   content: @Composable LazyItemScope.(index: Int) -> Unit,
 ) {
+  require(rowCount > 0) { "rowCount must be positive, was $rowCount" }
+  require(size.height > 0.dp) { "size.height must be positive, was ${size.height}" }
   val lazyListState = rememberLazyListState(startIndex)
   val flingBehavior = rememberSnapFlingBehavior(lazyListState)
   val latestOnScrollChanged by rememberUpdatedState(onScrollChanged)
@@ -91,9 +93,9 @@ internal fun WheelPicker(
               val distanceToCenterIndex = index - centerIndex
               val distanceToIndexSnap = distanceToCenterIndex * singleViewPortHeightPx - centerIndexOffset
               val distanceToIndexSnapAbs = abs(distanceToIndexSnap)
-              alpha = if (distanceToIndexSnapAbs in 0f..singleViewPortHeightPx)
+              alpha = if (distanceToIndexSnapAbs <= singleViewPortHeightPx)
                 1.2f - (distanceToIndexSnapAbs / singleViewPortHeightPx) else 0.2f
-              rotationX = (-20f * (distanceToIndexSnap / singleViewPortHeightPx)).takeUnless { it.isNaN() } ?: 0f
+              rotationX = -20f * (distanceToIndexSnap / singleViewPortHeightPx)
             },
           contentAlignment = Alignment.Center
         ) {


### PR DESCRIPTION
## Summary

- Defer `LazyListState` scroll reads for wheel item alpha/rotation into the `graphicsLayer` block
- Remove the composable `calculateAnimatedAlphaAndRotationX` helper to avoid scroll-driven recomposition work
- Fail fast when `WheelPicker` receives invalid `rowCount` or non-positive/non-finite height
- Remove NaN fallback logic now that invalid sizing inputs are rejected at the composable boundary
- Avoid allocating a `ClosedFloatRange` in the per-item scroll rendering path

## Motivation

Wheel item alpha and rotation are driven by scroll position. Reading that scroll state during composition causes unnecessary recomposition work while scrolling. Moving those reads into `graphicsLayer` keeps the high-frequency updates out of composition.

The previous NaN fallback masked invalid caller input, especially degenerate `rowCount` and height values. Rejecting those values up front gives a clearer failure at the call site and keeps the rendering path simpler.

## Verification

- Ran `./gradlew :datetime-wheel-picker:compileCommonMainKotlinMetadata`
