### PR TITLE
feat(core)!: support distinct selected item text styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 1.4.0 - Unreleased
+
+### Breaking changes
+
+- Renamed the public `WheelTextPicker` parameters `style` and `color` to
+  `textStyle` and `textColor`.
+- Added `selectedTextStyle` and `selectedTextColor` to the public
+  `WheelDatePicker`, `WheelTimePicker`, `WheelDateTimePicker`, and
+  `WheelTextPicker` APIs. This changes their binary signatures.
+- Applications and libraries compiled against 1.3.x must be recompiled after
+  upgrading. Positional calls that pass arguments after `textColor` may also
+  need to be updated.
+
+#### Migration
+
+Before:
+
+```kotlin
+WheelTextPicker(
+  texts = values,
+  rowCount = 3,
+  style = MaterialTheme.typography.titleMedium,
+  color = LocalContentColor.current,
+)
+```
+
+After:
+
+```kotlin
+WheelTextPicker(
+  texts = values,
+  rowCount = 3,
+  textStyle = MaterialTheme.typography.titleMedium,
+  textColor = LocalContentColor.current,
+  selectedTextStyle = MaterialTheme.typography.titleMedium.copy(
+    fontWeight = FontWeight.Bold,
+  ),
+  selectedTextColor = MaterialTheme.colorScheme.primary,
+)
+```
+
+### Added
+
+- Added independent text styles and colors for the selected (centered) wheel
+  item.
+- Applied selected-item styling to date, time, date-time, and text pickers,
+  including time separators and CJK date suffixes.
+
+### Changed
+
+- Partial picker text styles are now resolved against the default and inactive
+  styles.
+- Reduced selected-index recomposition to rows whose selected state changes.
+- Reduced text measurement work for CJK pickers.

--- a/README.MD
+++ b/README.MD
@@ -36,7 +36,7 @@ Arabic (العربية), Bengali (বাংলা), Chinese (中文), Czech (Če
 > **Contributions welcome**: If you find any translation errors or want to add support for a new language, please [open an issue](../../issues) or submit a pull request.
 
 ### 🎨 Visual Customization
-- Configurable size, row count, text style, and colors
+- Configurable size, row count, inactive and selected text styles, and colors
 - Customizable selector appearance (shape, color, border)
 - Material Design integration
 
@@ -191,6 +191,10 @@ WheelDateTimePicker(
   rowCount = 5,
   textStyle = MaterialTheme.typography.titleSmall,
   textColor = Color(0xFFffc300),
+  selectedTextStyle = MaterialTheme.typography.titleSmall.copy(
+    fontWeight = FontWeight.Bold
+  ),
+  selectedTextColor = Color.Black,
   selectorProperties = WheelPickerDefaults.selectorProperties(
     enabled = true,
     shape = RoundedCornerShape(0.dp),
@@ -222,8 +226,10 @@ WheelDateTimePicker(
 | `dateFormatter` | `DateFormatter` | Auto-detected | Controls date order, month style, and CJK suffixes |
 | `size` | `DpSize` | `DpSize(256.dp, 128.dp)` | Picker dimensions |
 | `rowCount` | `Int` | `3` | Number of visible rows in the wheel |
-| `textStyle` | `TextStyle` | `MaterialTheme.typography.titleMedium` | Text styling |
-| `textColor` | `Color` | `LocalContentColor.current` | Text color |
+| `textStyle` | `TextStyle` | `MaterialTheme.typography.titleMedium` | Text styling for inactive items |
+| `textColor` | `Color` | `LocalContentColor.current` | Text color for inactive items |
+| `selectedTextStyle` | `TextStyle` | `textStyle` | Text styling for the selected (centered) item |
+| `selectedTextColor` | `Color` | `textColor` | Text color for the selected (centered) item |
 | `selectorProperties` | `SelectorProperties` | Default | Selector appearance (shape, color, border) |
 | `onSnappedDateChanged` | `(LocalDate) -> Unit` | `{}` | Callback fired **during scrolling** every time the snapped date changes (live updates) |
 | `onSnappedDate` | `(LocalDate) -> Unit` | `{}` | Callback fired **when scrolling settles** on the final selected date |
@@ -260,7 +266,7 @@ WheelDateTimePicker(
 | `maxTime` | `LocalTime` | `LocalTime.MAX` | Maximum selectable time |
 | `timeFormatter` | `TimeFormatter` | Auto-detected | Controls 12/24 hour format (auto: AM/PM for en-US/GB, 24h for others) |
 | `size` | `DpSize` | `DpSize(128.dp, 128.dp)` | Picker dimensions (narrower than date picker) |
-| Other params | - | Same as `WheelDatePicker` | rowCount, textStyle, textColor, selectorProperties, etc. |
+| Other params | - | Same as `WheelDatePicker` | rowCount, textStyle, textColor, selectedTextStyle, selectedTextColor, selectorProperties, etc. |
 
 **TimeFormat**:
 - `TimeFormat.HOUR_24` - 24-hour format (00:00 - 23:59)
@@ -279,7 +285,22 @@ WheelDateTimePicker(
 | `size` | `DpSize` | `DpSize(256.dp, 128.dp)` | Picker dimensions |
 | `onSnappedDateTimeChanged` | `(LocalDateTime) -> Unit` | `{}` | Callback fired **during scrolling** every time the snapped date-time changes (live updates) |
 | `onSnappedDateTime` | `(LocalDateTime) -> Unit` | `{}` | Callback fired **when scrolling settles** on the final selected date-time |
-| Other params | - | Same as `WheelDatePicker` | rowCount, textStyle, textColor, selectorProperties |
+| Other params | - | Same as `WheelDatePicker` | rowCount, textStyle, textColor, selectedTextStyle, selectedTextColor, selectorProperties |
+
+### Styling the selected item
+
+Each picker accepts `selectedTextStyle` / `selectedTextColor` to style the **centered (snapped) item** differently from inactive items. By default, they use the same values as `textStyle` / `textColor`.
+
+```kotlin
+WheelDatePicker(
+  textStyle = MaterialTheme.typography.titleMedium,
+  textColor = LocalContentColor.current,
+  selectedTextStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+  selectedTextColor = MaterialTheme.colorScheme.primary,
+)
+```
+
+> `selectedTextColor` overrides `selectedTextStyle.color`, mirroring how `Text(color = ...)` overrides `TextStyle.color` in Compose. The same parameters are available on `WheelTimePicker`, `WheelDateTimePicker`, and the internal text pickers.
 
 ## Setup
 

--- a/README.MD
+++ b/README.MD
@@ -302,6 +302,8 @@ WheelDatePicker(
 
 > `selectedTextColor` overrides `selectedTextStyle.color`, mirroring how `Text(color = ...)` overrides `TextStyle.color` in Compose. The same parameters are available on `WheelTimePicker`, `WheelDateTimePicker`, and the internal text pickers.
 
+> In `WheelTimePicker` and `WheelDateTimePicker`, the colon separator sits in the center row next to the selected hour and minute, so it follows `selectedTextStyle` / `selectedTextColor`. If you don't set the `selected*` params (defaults equal `textStyle` / `textColor`), the colon is unchanged.
+
 ## Setup
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.darkokoa/datetime-wheel-picker?style=flat)](https://central.sonatype.com/artifact/io.github.darkokoa/datetime-wheel-picker)

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/WheelDatePicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/WheelDatePicker.kt
@@ -37,6 +37,8 @@ fun WheelDatePicker(
   rowCount: Int = 3,
   textStyle: TextStyle = MaterialTheme.typography.titleMedium,
   textColor: Color = LocalContentColor.current,
+  selectedTextStyle: TextStyle = textStyle,
+  selectedTextColor: Color = textColor,
   selectorProperties: SelectorProperties = WheelPickerDefaults.selectorProperties(),
   onSnappedDateChanged: (snappedDate: LocalDate) -> Unit = {},
   onSnappedDate: (snappedDate: LocalDate) -> Unit = {},
@@ -52,6 +54,8 @@ fun WheelDatePicker(
     rowCount,
     textStyle,
     textColor,
+    selectedTextStyle,
+    selectedTextColor,
     selectorProperties,
     onSnappedDate = { snappedDate ->
       onSnappedDate(snappedDate.snappedLocalDate)

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/WheelDateTimePicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/WheelDateTimePicker.kt
@@ -40,6 +40,8 @@ fun WheelDateTimePicker(
   rowCount: Int = 3,
   textStyle: TextStyle = MaterialTheme.typography.titleMedium,
   textColor: Color = LocalContentColor.current,
+  selectedTextStyle: TextStyle = textStyle,
+  selectedTextColor: Color = textColor,
   selectorProperties: SelectorProperties = WheelPickerDefaults.selectorProperties(),
   onSnappedDateTimeChanged: (snappedDateTime: LocalDateTime) -> Unit = {},
   onSnappedDateTime: (snappedDateTime: LocalDateTime) -> Unit = {},
@@ -56,6 +58,8 @@ fun WheelDateTimePicker(
     rowCount,
     textStyle,
     textColor,
+    selectedTextStyle,
+    selectedTextColor,
     selectorProperties,
     onSnappedDateTime = { snappedDateTime ->
       onSnappedDateTime(snappedDateTime.snappedLocalDateTime)

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/WheelTimePicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/WheelTimePicker.kt
@@ -30,6 +30,8 @@ fun WheelTimePicker(
   rowCount: Int = 3,
   textStyle: TextStyle = MaterialTheme.typography.titleMedium,
   textColor: Color = LocalContentColor.current,
+  selectedTextStyle: TextStyle = textStyle,
+  selectedTextColor: Color = textColor,
   selectorProperties: SelectorProperties = WheelPickerDefaults.selectorProperties(),
   onSnappedTimeChanged: (snappedTime: LocalTime) -> Unit = {},
   onSnappedTime: (snappedTime: LocalTime) -> Unit = {},
@@ -44,6 +46,8 @@ fun WheelTimePicker(
     rowCount,
     textStyle,
     textColor,
+    selectedTextStyle,
+    selectedTextColor,
     selectorProperties,
     onSnappedTime = { snappedTime, _ ->
       onSnappedTime(snappedTime.snappedLocalTime)

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/AdaptiveWheelDatePicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/AdaptiveWheelDatePicker.kt
@@ -31,6 +31,8 @@ internal fun AdaptiveWheelDatePicker(
   rowCount: Int = 3,
   textStyle: TextStyle = MaterialTheme.typography.titleMedium,
   textColor: Color = LocalContentColor.current,
+  selectedTextStyle: TextStyle = textStyle,
+  selectedTextColor: Color = textColor,
   selectorProperties: SelectorProperties = WheelPickerDefaults.selectorProperties(),
   onSnappedDateChanged: (snappedDate: SnappedDate) -> Unit = {},
   onSnappedDate: (snappedDate: SnappedDate) -> Int? = { _ -> null },
@@ -47,6 +49,8 @@ internal fun AdaptiveWheelDatePicker(
       rowCount,
       textStyle,
       textColor,
+      selectedTextStyle,
+      selectedTextColor,
       selectorProperties,
       onSnappedDateChanged,
       onSnappedDate
@@ -63,6 +67,8 @@ internal fun AdaptiveWheelDatePicker(
       rowCount,
       textStyle,
       textColor,
+      selectedTextStyle,
+      selectedTextColor,
       selectorProperties,
       onSnappedDateChanged,
       onSnappedDate

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/AdaptiveWheelDateTimePicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/AdaptiveWheelDateTimePicker.kt
@@ -41,6 +41,8 @@ internal fun AdaptiveWheelDateTimePicker(
   rowCount: Int = 3,
   textStyle: TextStyle = MaterialTheme.typography.titleMedium,
   textColor: Color = LocalContentColor.current,
+  selectedTextStyle: TextStyle = textStyle,
+  selectedTextColor: Color = textColor,
   selectorProperties: SelectorProperties = WheelPickerDefaults.selectorProperties(),
   onSnappedDateTimeChanged: (snappedDateTime: SnappedDateTime) -> Unit = {},
   onSnappedDateTime: (snappedDateTime: SnappedDateTime) -> Int? = { _ -> null },
@@ -75,6 +77,8 @@ internal fun AdaptiveWheelDateTimePicker(
         rowCount = rowCount,
         textStyle = textStyle,
         textColor = textColor,
+        selectedTextStyle = selectedTextStyle,
+        selectedTextColor = selectedTextColor,
         selectorProperties = WheelPickerDefaults.selectorProperties(
           enabled = false
         ),
@@ -138,6 +142,8 @@ internal fun AdaptiveWheelDateTimePicker(
         rowCount = rowCount,
         textStyle = textStyle,
         textColor = textColor,
+        selectedTextStyle = selectedTextStyle,
+        selectedTextColor = selectedTextColor,
         selectorProperties = WheelPickerDefaults.selectorProperties(
           enabled = false
         ),
@@ -182,7 +188,6 @@ internal fun AdaptiveWheelDateTimePicker(
     }
   }
 }
-
 
 
 

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/CJKWheelDatePicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/CJKWheelDatePicker.kt
@@ -42,6 +42,8 @@ internal fun CJKWheelDatePicker(
   rowCount: Int = 3,
   textStyle: TextStyle = MaterialTheme.typography.titleMedium,
   textColor: Color = LocalContentColor.current,
+  selectedTextStyle: TextStyle = textStyle,
+  selectedTextColor: Color = textColor,
   selectorProperties: SelectorProperties = WheelPickerDefaults.selectorProperties(),
   onSnappedDateChanged: (snappedDate: SnappedDate) -> Unit = {},
   onSnappedDate: (snappedDate: SnappedDate) -> Int? = { _ -> null },
@@ -84,8 +86,12 @@ internal fun CJKWheelDatePicker(
               suffix = if (dateFormatter.cjkSuffixConfig.showDaySuffix) strings.daySuffix else "",
               textToSuffixSpacing = dateFormatter.cjkSuffixConfig.daySuffixSpacing,
               rowCount = rowCount,
-              style = textStyle,
-              color = textColor,
+              textStyle = textStyle,
+              textColor = textColor,
+              selectedTextStyle = selectedTextStyle,
+              selectedTextColor = selectedTextColor,
+              suffixTextStyle = selectedTextStyle,
+              suffixTextColor = selectedTextColor,
               selectorProperties = WheelPickerDefaults.selectorProperties(
                 enabled = false
               ),
@@ -133,8 +139,12 @@ internal fun CJKWheelDatePicker(
               suffix = if (dateFormatter.cjkSuffixConfig.showMonthSuffix) strings.monthSuffix else "",
               textToSuffixSpacing = dateFormatter.cjkSuffixConfig.monthSuffixSpacing,
               rowCount = rowCount,
-              style = textStyle,
-              color = textColor,
+              textStyle = textStyle,
+              textColor = textColor,
+              selectedTextStyle = selectedTextStyle,
+              selectedTextColor = selectedTextColor,
+              suffixTextStyle = selectedTextStyle,
+              suffixTextColor = selectedTextColor,
               selectorProperties = WheelPickerDefaults.selectorProperties(
                 enabled = false
               ),
@@ -182,8 +192,12 @@ internal fun CJKWheelDatePicker(
                 suffix = if (dateFormatter.cjkSuffixConfig.showYearSuffix) strings.yearSuffix else "",
                 textToSuffixSpacing = dateFormatter.cjkSuffixConfig.yearSuffixSpacing,
                 rowCount = rowCount,
-                style = textStyle,
-                color = textColor,
+                textStyle = textStyle,
+                textColor = textColor,
+                selectedTextStyle = selectedTextStyle,
+                selectedTextColor = selectedTextColor,
+                suffixTextStyle = selectedTextStyle,
+                suffixTextColor = selectedTextColor,
                 selectorProperties = WheelPickerDefaults.selectorProperties(
                   enabled = false
                 ),

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/StandardWheelDatePicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/StandardWheelDatePicker.kt
@@ -38,6 +38,8 @@ internal fun StandardWheelDatePicker(
   rowCount: Int = 3,
   textStyle: TextStyle = MaterialTheme.typography.titleMedium,
   textColor: Color = LocalContentColor.current,
+  selectedTextStyle: TextStyle = textStyle,
+  selectedTextColor: Color = textColor,
   selectorProperties: SelectorProperties = WheelPickerDefaults.selectorProperties(),
   onSnappedDateChanged: (snappedDate: SnappedDate) -> Unit = {},
   onSnappedDate: (snappedDate: SnappedDate) -> Int? = { _ -> null },
@@ -75,8 +77,10 @@ internal fun StandardWheelDatePicker(
               ),
               texts = dayOfMonths.map { it.text },
               rowCount = rowCount,
-              style = textStyle,
-              color = textColor,
+              textStyle = textStyle,
+              textColor = textColor,
+              selectedTextStyle = selectedTextStyle,
+              selectedTextColor = selectedTextColor,
               selectorProperties = WheelPickerDefaults.selectorProperties(
                 enabled = false
               ),
@@ -121,8 +125,10 @@ internal fun StandardWheelDatePicker(
               ),
               texts = months.map { it.text },
               rowCount = rowCount,
-              style = textStyle,
-              color = textColor,
+              textStyle = textStyle,
+              textColor = textColor,
+              selectedTextStyle = selectedTextStyle,
+              selectedTextColor = selectedTextColor,
               selectorProperties = WheelPickerDefaults.selectorProperties(
                 enabled = false
               ),
@@ -173,8 +179,10 @@ internal fun StandardWheelDatePicker(
                 ),
                 texts = years.map { it.text },
                 rowCount = rowCount,
-                style = textStyle,
-                color = textColor,
+                textStyle = textStyle,
+                textColor = textColor,
+                selectedTextStyle = selectedTextStyle,
+                selectedTextColor = selectedTextColor,
                 selectorProperties = WheelPickerDefaults.selectorProperties(
                   enabled = false
                 ),

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/StandardWheelTimePicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/StandardWheelTimePicker.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -43,6 +44,13 @@ internal fun StandardWheelTimePicker(
   onSnappedTimeChanged: (snappedTime: SnappedTime, timeFormat: TimeFormat) -> Unit = { _, _ -> },
   onSnappedTime: (snappedTime: SnappedTime, timeFormat: TimeFormat) -> Int? = { _, _ -> null },
 ) {
+  val defaultTextStyle = MaterialTheme.typography.titleMedium
+  val resolvedTextStyle = remember(defaultTextStyle, textStyle) {
+    defaultTextStyle.merge(textStyle)
+  }
+  val resolvedSelectedTextStyle = remember(resolvedTextStyle, selectedTextStyle) {
+    resolvedTextStyle.merge(selectedTextStyle)
+  }
 
   val itemCount = remember(timeFormatter.timeFormat) {
     if (timeFormatter.timeFormat == TimeFormat.AM_PM) 3 else 2
@@ -90,9 +98,9 @@ internal fun StandardWheelTimePicker(
         ),
         texts = if (timeFormatter.timeFormat == TimeFormat.HOUR_24) hours.map { it.text } else amPmHours.map { it.text },
         rowCount = rowCount,
-        textStyle = textStyle,
+        textStyle = resolvedTextStyle,
         textColor = textColor,
-        selectedTextStyle = selectedTextStyle,
+        selectedTextStyle = resolvedSelectedTextStyle,
         selectedTextColor = selectedTextColor,
         startIndex = if (timeFormatter.timeFormat == TimeFormat.HOUR_24) {
           hours.find { it.value == startTime.hour }?.index ?: 0
@@ -154,7 +162,7 @@ internal fun StandardWheelTimePicker(
       //Colon
       TimeSeparator(
         modifier = Modifier.align(Alignment.CenterVertically).width(0.dp),
-        textStyle = selectedTextStyle.copy(color = selectedTextColor),
+        textStyle = resolvedSelectedTextStyle.copy(color = selectedTextColor),
       )
 
       //Minute
@@ -165,9 +173,9 @@ internal fun StandardWheelTimePicker(
         ),
         texts = minutes.map { it.text },
         rowCount = rowCount,
-        textStyle = textStyle,
+        textStyle = resolvedTextStyle,
         textColor = textColor,
-        selectedTextStyle = selectedTextStyle,
+        selectedTextStyle = resolvedSelectedTextStyle,
         selectedTextColor = selectedTextColor,
         startIndex = minutes.find { it.value == startTime.minute }?.index ?: 0,
         selectorProperties = WheelPickerDefaults.selectorProperties(
@@ -230,9 +238,9 @@ internal fun StandardWheelTimePicker(
           ),
           texts = amPms.map { it.text },
           rowCount = rowCount,
-          textStyle = textStyle,
+          textStyle = resolvedTextStyle,
           textColor = textColor,
-          selectedTextStyle = selectedTextStyle,
+          selectedTextStyle = resolvedSelectedTextStyle,
           selectedTextColor = selectedTextColor,
           startIndex = amPms.find { it.value == amPmValueFromTime(startTime) }?.index ?: 0,
           selectorProperties = WheelPickerDefaults.selectorProperties(
@@ -302,10 +310,14 @@ fun TimeSeparator(
   spacingRatio: Float = 0.25f
 ) {
   val density = LocalDensity.current
+  val defaultTextStyle = MaterialTheme.typography.titleMedium
+  val resolvedTextStyle = remember(defaultTextStyle, textStyle) {
+    defaultTextStyle.merge(textStyle)
+  }
 
-  val fontSize = textStyle.fontSize
-  val fontWeight = textStyle.fontWeight ?: FontWeight.Normal
-  val color = textStyle.color
+  val fontSize = resolvedTextStyle.fontSize
+  val fontWeight = resolvedTextStyle.fontWeight ?: FontWeight.Normal
+  val color = resolvedTextStyle.color.takeOrElse { LocalContentColor.current }
 
   val fontSizePx = with(density) { fontSize.toPx() }
   val baseDotSizePx = fontSizePx * dotSizeRatio

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/StandardWheelTimePicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/StandardWheelTimePicker.kt
@@ -37,6 +37,8 @@ internal fun StandardWheelTimePicker(
   rowCount: Int = 3,
   textStyle: TextStyle = MaterialTheme.typography.titleMedium,
   textColor: Color = LocalContentColor.current,
+  selectedTextStyle: TextStyle = textStyle,
+  selectedTextColor: Color = textColor,
   selectorProperties: SelectorProperties = WheelPickerDefaults.selectorProperties(),
   onSnappedTimeChanged: (snappedTime: SnappedTime, timeFormat: TimeFormat) -> Unit = { _, _ -> },
   onSnappedTime: (snappedTime: SnappedTime, timeFormat: TimeFormat) -> Int? = { _, _ -> null },
@@ -88,8 +90,10 @@ internal fun StandardWheelTimePicker(
         ),
         texts = if (timeFormatter.timeFormat == TimeFormat.HOUR_24) hours.map { it.text } else amPmHours.map { it.text },
         rowCount = rowCount,
-        style = textStyle,
-        color = textColor,
+        textStyle = textStyle,
+        textColor = textColor,
+        selectedTextStyle = selectedTextStyle,
+        selectedTextColor = selectedTextColor,
         startIndex = if (timeFormatter.timeFormat == TimeFormat.HOUR_24) {
           hours.find { it.value == startTime.hour }?.index ?: 0
         } else amPmHours.find { it.value == localTimeToAmPmHour(startTime) }?.index ?: 0,
@@ -150,7 +154,7 @@ internal fun StandardWheelTimePicker(
       //Colon
       TimeSeparator(
         modifier = Modifier.align(Alignment.CenterVertically).width(0.dp),
-        textStyle = textStyle.copy(color = textColor),
+        textStyle = selectedTextStyle.copy(color = selectedTextColor),
       )
 
       //Minute
@@ -161,8 +165,10 @@ internal fun StandardWheelTimePicker(
         ),
         texts = minutes.map { it.text },
         rowCount = rowCount,
-        style = textStyle,
-        color = textColor,
+        textStyle = textStyle,
+        textColor = textColor,
+        selectedTextStyle = selectedTextStyle,
+        selectedTextColor = selectedTextColor,
         startIndex = minutes.find { it.value == startTime.minute }?.index ?: 0,
         selectorProperties = WheelPickerDefaults.selectorProperties(
           enabled = false
@@ -224,8 +230,10 @@ internal fun StandardWheelTimePicker(
           ),
           texts = amPms.map { it.text },
           rowCount = rowCount,
-          style = textStyle,
-          color = textColor,
+          textStyle = textStyle,
+          textColor = textColor,
+          selectedTextStyle = selectedTextStyle,
+          selectedTextColor = selectedTextColor,
           startIndex = amPms.find { it.value == amPmValueFromTime(startTime) }?.index ?: 0,
           selectorProperties = WheelPickerDefaults.selectorProperties(
             enabled = false

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
@@ -48,12 +48,12 @@ internal fun WheelPicker(
   val singleViewPortHeightPx = remember(size, rowCount, density) {
     with(density) { size.height.toPx() } / rowCount
   }
-  val snappedItemIndex by remember(lazyListState) {
+  val snappedItemIndexState = remember(lazyListState) {
     derivedStateOf { calculateSnappedItemIndex(lazyListState) }
   }
 
   LaunchedEffect(lazyListState, count) {
-    snapshotFlow { calculateSnappedItemIndex(lazyListState) }
+    snapshotFlow { snappedItemIndexState.value }
       .distinctUntilChanged()
       .collect { latestOnScrollChanged(it) }
   }
@@ -89,6 +89,9 @@ internal fun WheelPicker(
       flingBehavior = flingBehavior
     ) {
       items(count) { index ->
+        val isSelected by remember(snappedItemIndexState, index) {
+          derivedStateOf { index == snappedItemIndexState.value }
+        }
         Box(
           modifier = Modifier
             .height(size.height / rowCount)
@@ -105,7 +108,7 @@ internal fun WheelPicker(
             },
           contentAlignment = Alignment.Center
         ) {
-          content(index, index == snappedItemIndex)
+          content(index, isSelected)
         }
       }
     }

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
@@ -34,7 +34,7 @@ internal fun WheelPicker(
   selectorProperties: SelectorProperties = WheelPickerDefaults.selectorProperties(),
   onScrollChanged: (snappedIndex: Int) -> Unit = {},
   onScrollFinished: (snappedIndex: Int) -> Int? = { null },
-  content: @Composable LazyItemScope.(index: Int) -> Unit,
+  content: @Composable LazyItemScope.(index: Int, isSelected: Boolean) -> Unit,
 ) {
   require(rowCount > 0) { "rowCount must be positive, was $rowCount" }
   require(size.height.isFinite && size.height > 0.dp) {
@@ -47,6 +47,9 @@ internal fun WheelPicker(
   val density = LocalDensity.current
   val singleViewPortHeightPx = remember(size, rowCount, density) {
     with(density) { size.height.toPx() } / rowCount
+  }
+  val snappedItemIndex by remember(lazyListState) {
+    derivedStateOf { calculateSnappedItemIndex(lazyListState) }
   }
 
   LaunchedEffect(lazyListState, count) {
@@ -102,7 +105,7 @@ internal fun WheelPicker(
             },
           contentAlignment = Alignment.Center
         ) {
-          content(index)
+          content(index, index == snappedItemIndex)
         }
       }
     }

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelTextPicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelTextPicker.kt
@@ -39,6 +39,14 @@ fun WheelTextPicker(
   onScrollChanged: (snappedIndex: Int) -> Unit = {},
   onScrollFinished: (snappedIndex: Int) -> Int? = { null },
 ) {
+  val defaultTextStyle = MaterialTheme.typography.titleMedium
+  val resolvedTextStyle = remember(defaultTextStyle, textStyle) {
+    defaultTextStyle.merge(textStyle)
+  }
+  val resolvedSelectedTextStyle = remember(resolvedTextStyle, selectedTextStyle) {
+    resolvedTextStyle.merge(selectedTextStyle)
+  }
+
   WheelPicker(
     modifier = modifier,
     startIndex = startIndex,
@@ -51,7 +59,7 @@ fun WheelTextPicker(
   ) { index, isSelected ->
     Text(
       text = texts[index],
-      style = if (isSelected) selectedTextStyle else textStyle,
+      style = if (isSelected) resolvedSelectedTextStyle else resolvedTextStyle,
       color = if (isSelected) selectedTextColor else textColor,
       maxLines = 1,
       textAlign = TextAlign.Center
@@ -78,14 +86,24 @@ internal fun WheelTextPickerWithSuffix(
   onScrollChanged: (snappedIndex: Int) -> Unit = {},
   onScrollFinished: (snappedIndex: Int) -> Int? = { null },
 ) {
+  val defaultTextStyle = MaterialTheme.typography.titleMedium
+  val resolvedTextStyle = remember(defaultTextStyle, textStyle) {
+    defaultTextStyle.merge(textStyle)
+  }
+  val resolvedSelectedTextStyle = remember(resolvedTextStyle, selectedTextStyle) {
+    resolvedTextStyle.merge(selectedTextStyle)
+  }
+  val resolvedSuffixTextStyle = remember(resolvedTextStyle, suffixTextStyle) {
+    resolvedTextStyle.merge(suffixTextStyle)
+  }
   val textMeasurer = rememberTextMeasurer()
   val density = LocalDensity.current
 
-  val suffixWidth = remember(suffix, suffixTextStyle, density, textMeasurer) {
+  val suffixWidth = remember(suffix, resolvedSuffixTextStyle, density, textMeasurer) {
     if (suffix.isNotEmpty()) {
       val textLayoutResult = textMeasurer.measure(
         text = AnnotatedString(suffix),
-        style = suffixTextStyle,
+        style = resolvedSuffixTextStyle,
         maxLines = 1
       )
       with(density) { textLayoutResult.size.width.toDp() }
@@ -99,14 +117,14 @@ internal fun WheelTextPickerWithSuffix(
     if (hasSuffix) texts.maxByOrNull { it.length } else null
   }
 
-  val textWidth = remember(widthReferenceText, selectedTextStyle, density, textMeasurer) {
+  val textWidth = remember(widthReferenceText, resolvedSelectedTextStyle, density, textMeasurer) {
     if (widthReferenceText == null) {
       0.dp
     } else {
       with(density) {
         textMeasurer.measure(
           text = AnnotatedString(widthReferenceText),
-          style = selectedTextStyle,
+          style = resolvedSelectedTextStyle,
           maxLines = 1
         ).size.width.toDp()
       }
@@ -130,7 +148,7 @@ internal fun WheelTextPickerWithSuffix(
       ) {
         Text(
           text = texts[index],
-          style = if (isSelected) selectedTextStyle else textStyle,
+          style = if (isSelected) resolvedSelectedTextStyle else resolvedTextStyle,
           color = if (isSelected) selectedTextColor else textColor,
           maxLines = 1,
           textAlign = TextAlign.Center
@@ -147,7 +165,7 @@ internal fun WheelTextPickerWithSuffix(
         modifier = Modifier
           .align(Alignment.Center)
           .padding(start = textWidth + textToSuffixSpacing),
-        style = suffixTextStyle,
+        style = resolvedSuffixTextStyle,
         color = suffixTextColor,
         maxLines = 1
       )

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelTextPicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelTextPicker.kt
@@ -94,20 +94,21 @@ internal fun WheelTextPickerWithSuffix(
     }
   }
 
-  val textWidth = remember(texts, textStyle, selectedTextStyle, density, textMeasurer) {
-    if (texts.isEmpty()) {
+  val hasSuffix = suffix.isNotEmpty()
+  val widthReferenceText = remember(texts, hasSuffix) {
+    if (hasSuffix) texts.maxByOrNull { it.length } else null
+  }
+
+  val textWidth = remember(widthReferenceText, selectedTextStyle, density, textMeasurer) {
+    if (widthReferenceText == null) {
       0.dp
     } else {
       with(density) {
-        listOf(textStyle, selectedTextStyle).distinct().maxOf { style ->
-          texts.maxOf { text ->
-            textMeasurer.measure(
-              text = AnnotatedString(text),
-              style = style,
-              maxLines = 1
-            ).size.width
-          }
-        }.toDp()
+        textMeasurer.measure(
+          text = AnnotatedString(widthReferenceText),
+          style = selectedTextStyle,
+          maxLines = 1
+        ).size.width.toDp()
       }
     }
   }

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelTextPicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelTextPicker.kt
@@ -31,8 +31,10 @@ fun WheelTextPicker(
   size: DpSize = DpSize(128.dp, 128.dp),
   texts: List<String>,
   rowCount: Int,
-  style: TextStyle = MaterialTheme.typography.titleMedium,
-  color: Color = LocalContentColor.current,
+  textStyle: TextStyle = MaterialTheme.typography.titleMedium,
+  textColor: Color = LocalContentColor.current,
+  selectedTextStyle: TextStyle = textStyle,
+  selectedTextColor: Color = textColor,
   selectorProperties: SelectorProperties = WheelPickerDefaults.selectorProperties(),
   onScrollChanged: (snappedIndex: Int) -> Unit = {},
   onScrollFinished: (snappedIndex: Int) -> Int? = { null },
@@ -46,11 +48,11 @@ fun WheelTextPicker(
     selectorProperties = selectorProperties,
     onScrollFinished = onScrollFinished,
     onScrollChanged = onScrollChanged
-  ) { index ->
+  ) { index, isSelected ->
     Text(
       text = texts[index],
-      style = style,
-      color = color,
+      style = if (isSelected) selectedTextStyle else textStyle,
+      color = if (isSelected) selectedTextColor else textColor,
       maxLines = 1,
       textAlign = TextAlign.Center
     )
@@ -64,11 +66,13 @@ internal fun WheelTextPickerWithSuffix(
   size: DpSize = DpSize(128.dp, 128.dp),
   texts: List<String>,
   rowCount: Int,
-  style: TextStyle = MaterialTheme.typography.titleMedium,
-  color: Color = LocalContentColor.current,
+  textStyle: TextStyle = MaterialTheme.typography.titleMedium,
+  textColor: Color = LocalContentColor.current,
+  selectedTextStyle: TextStyle = textStyle,
+  selectedTextColor: Color = textColor,
   suffix: String = "",
-  suffixStyle: TextStyle = style,
-  suffixColor: Color = color,
+  suffixTextStyle: TextStyle = selectedTextStyle,
+  suffixTextColor: Color = selectedTextColor,
   textToSuffixSpacing: Dp = 8.dp,
   selectorProperties: SelectorProperties = WheelPickerDefaults.selectorProperties(),
   onScrollChanged: (snappedIndex: Int) -> Unit = {},
@@ -77,11 +81,12 @@ internal fun WheelTextPickerWithSuffix(
   val textMeasurer = rememberTextMeasurer()
   val density = LocalDensity.current
 
-  val suffixWidth = remember(suffix, suffixStyle) {
+  val suffixWidth = remember(suffix, suffixTextStyle, density, textMeasurer) {
     if (suffix.isNotEmpty()) {
       val textLayoutResult = textMeasurer.measure(
         text = AnnotatedString(suffix),
-        style = suffixStyle
+        style = suffixTextStyle,
+        maxLines = 1
       )
       with(density) { textLayoutResult.size.width.toDp() }
     } else {
@@ -89,12 +94,22 @@ internal fun WheelTextPickerWithSuffix(
     }
   }
 
-  val textWidth = remember(style) {
-      val textLayoutResult = textMeasurer.measure(
-        text = AnnotatedString(texts.last()),
-        style = style
-      )
-      with(density) { textLayoutResult.size.width.toDp() }
+  val textWidth = remember(texts, textStyle, selectedTextStyle, density, textMeasurer) {
+    if (texts.isEmpty()) {
+      0.dp
+    } else {
+      with(density) {
+        listOf(textStyle, selectedTextStyle).distinct().maxOf { style ->
+          texts.maxOf { text ->
+            textMeasurer.measure(
+              text = AnnotatedString(text),
+              style = style,
+              maxLines = 1
+            ).size.width
+          }
+        }.toDp()
+      }
+    }
   }
 
   Box(modifier = modifier) {
@@ -106,7 +121,7 @@ internal fun WheelTextPickerWithSuffix(
       selectorProperties = selectorProperties,
       onScrollFinished = onScrollFinished,
       onScrollChanged = onScrollChanged
-    ) { index ->
+    ) { index, isSelected ->
       Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center,
@@ -114,8 +129,8 @@ internal fun WheelTextPickerWithSuffix(
       ) {
         Text(
           text = texts[index],
-          style = style,
-          color = color,
+          style = if (isSelected) selectedTextStyle else textStyle,
+          color = if (isSelected) selectedTextColor else textColor,
           maxLines = 1,
           textAlign = TextAlign.Center
         )
@@ -131,8 +146,8 @@ internal fun WheelTextPickerWithSuffix(
         modifier = Modifier
           .align(Alignment.Center)
           .padding(start = textWidth + textToSuffixSpacing),
-        style = suffixStyle,
-        color = suffixColor,
+        style = suffixTextStyle,
+        color = suffixTextColor,
         maxLines = 1
       )
     }

--- a/sample/composeApp/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/App.kt
+++ b/sample/composeApp/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/App.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import dev.darkokoa.datetimewheelpicker.core.WheelPickerDefaults
@@ -47,6 +48,14 @@ fun App() = AppTheme {
         println(snappedTime)
       }
       WheelDatePicker { snappedDate ->
+        println(snappedDate)
+      }
+      WheelDatePicker(
+        textStyle = MaterialTheme.typography.titleMedium,
+        textColor = LocalContentColor.current,
+        selectedTextStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+        selectedTextColor = MaterialTheme.colorScheme.primary,
+      ) { snappedDate ->
         println(snappedDate)
       }
       WheelDateTimePicker { snappedDateTime ->


### PR DESCRIPTION
## Summary

Adds independent styling for the selected (centered) wheel item.

- Add `selectedTextStyle` and `selectedTextColor` to `WheelDatePicker`,
  `WheelTimePicker`, `WheelDateTimePicker`, and `WheelTextPicker`
- Apply the selected-item styling to time separators and CJK date suffixes
- Resolve partial `TextStyle` values against the default and inactive styles
- Scope selection-driven recomposition to rows whose `isSelected` value changes
- Reduce text measurement work for CJK pickers
- Update the README, sample application, and changelog

## ⚠️ Breaking changes

These breaking changes are intentionally included in version `1.4.0`.

- Rename the public `WheelTextPicker` parameters:
  - `style` → `textStyle`
  - `color` → `textColor`
- Add `selectedTextStyle` and `selectedTextColor` to the public picker function
  signatures, making them binary-incompatible with 1.3.x
- Require applications and libraries compiled against 1.3.x to be recompiled
  after upgrading
- Require positional calls that pass `selectorProperties` or callback arguments
  to be reviewed because the new parameters were inserted before them

### Migration

Before:

```kotlin
WheelTextPicker(
  texts = values,
  rowCount = 3,
  style = MaterialTheme.typography.titleMedium,
  color = LocalContentColor.current,
)
```

After:

```kotlin
WheelTextPicker(
  texts = values,
  rowCount = 3,
  textStyle = MaterialTheme.typography.titleMedium,
  textColor = LocalContentColor.current,
  selectedTextStyle = MaterialTheme.typography.titleMedium.copy(
    fontWeight = FontWeight.Bold,
  ),
  selectedTextColor = MaterialTheme.colorScheme.primary,
)
```

## Behavior

- By default, selected and inactive items use the same supplied style and color:
  `selectedTextStyle = textStyle` and `selectedTextColor = textColor`
- When specified, `selectedTextColor` takes precedence over
  `selectedTextStyle.color`, matching the behavior of the Compose `Text` API
- The centered time separator uses the selected font size, font weight, and
  color
- CJK date suffixes follow the selected text style and color

## Testing

- [x] JVM tests pass
- [x] JVM, Android, JS, and Wasm targets compile
- [x] GitHub Actions CI passes
- [x] Selected styling is visually verified in the sample application

## Documentation

- [x] README updated
- [x] Sample application updated
- [x] `CHANGELOG.md` added with the 1.4.0 migration notes
