### PR TITLE
fix(core): prevent duplicate and initial-composition wheel callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
-## 1.4.0 - Unreleased
+## 1.4.1 - Unreleased
+
+### Fixed
+
+- Wheel callbacks no longer fire on first composition: initially positioning
+  the wheels at `startDate`/`startTime` no longer triggers `onScrollChanged` /
+  `onSnappedDateChanged` ([#71](https://github.com/darkokoa/compose-datetime-wheel-picker/issues/71)).
+- Wheel callbacks no longer fire twice for a single scroll gesture: the brief
+  idle gap between the end of a drag and the start of the snap fling could be
+  misreported as a finished scroll ([#71](https://github.com/darkokoa/compose-datetime-wheel-picker/issues/71)).
+- `startDate`/`startTime` outside the `minDate`/`maxDate` (`minTime`/`maxTime`)
+  bounds is now coerced into range, keeping the initial wheel position
+  consistent with the reported callback values.
+- Date pickers now deduplicate consecutive `onSnappedDateChanged` notifications
+  that resolve to the same date, so multiple wheel columns reporting the same
+  snapped date only notify once.
+
+## 1.4.0 - 2026-07-28
 
 ### Breaking changes
 

--- a/datetime-wheel-picker/build.gradle.kts
+++ b/datetime-wheel-picker/build.gradle.kts
@@ -79,6 +79,11 @@ kotlin {
     jvmMain.dependencies {
     }
 
+    jvmTest.dependencies {
+      implementation(libs.compose.ui.test)
+      implementation(compose.desktop.currentOs)
+    }
+
     jsMain.dependencies {
     }
 

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/CJKWheelDatePicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/CJKWheelDatePicker.kt
@@ -53,7 +53,18 @@ internal fun CJKWheelDatePicker(
 
   val itemWidth = Dp.Infinity
 
-  var snappedDate by remember { mutableStateOf(startDate) }
+  val initialDate = remember(startDate, minDate, maxDate) {
+    startDate.coerceIn(minDate, maxDate)
+  }
+
+  var snappedDate by remember { mutableStateOf(initialDate) }
+
+  val snappedDateChangeNotifier = remember { SnappedChangeNotifier<LocalDate>() }
+  val notifySnappedDateChanged: (SnappedDate) -> Unit = { newSnappedDate ->
+    snappedDateChangeNotifier.notifyIfChanged(newSnappedDate.snappedLocalDate) {
+      onSnappedDateChanged(newSnappedDate)
+    }
+  }
 
   val dayOfMonths =
     rememberFormattedDayOfMonths(snappedDate.month.number, snappedDate.year, dateFormatter)
@@ -95,7 +106,7 @@ internal fun CJKWheelDatePicker(
               selectorProperties = WheelPickerDefaults.selectorProperties(
                 enabled = false
               ),
-              startIndex = dayOfMonths.find { it.value == startDate.day }?.index ?: 0,
+              startIndex = dayOfMonths.find { it.value == initialDate.day }?.index ?: 0,
               onScrollFinished = { snappedIndex ->
                 val newDayOfMonth = dayOfMonths.find { it.index == snappedIndex }?.value
 
@@ -122,7 +133,7 @@ internal fun CJKWheelDatePicker(
               },
               onScrollChanged = { snappedIndex ->
                 dayOfMonths.find { it.index == snappedIndex }?.value?.let { newDay ->
-                  onSnappedDateChanged(SnappedDate.DayOfMonth(localDate = snappedDate.withDayOfMonth(newDay), index = snappedIndex))
+                  notifySnappedDateChanged(SnappedDate.DayOfMonth(localDate = snappedDate.withDayOfMonth(newDay), index = snappedIndex))
                 }
               }
             )
@@ -148,7 +159,7 @@ internal fun CJKWheelDatePicker(
               selectorProperties = WheelPickerDefaults.selectorProperties(
                 enabled = false
               ),
-              startIndex = months.find { it.value == startDate.month.number }?.index ?: 0,
+              startIndex = months.find { it.value == initialDate.month.number }?.index ?: 0,
               onScrollFinished = { snappedIndex ->
                 val newMonth = months.find { it.index == snappedIndex }?.value
                 newMonth?.let {
@@ -174,7 +185,7 @@ internal fun CJKWheelDatePicker(
               },
               onScrollChanged = { snappedIndex ->
                 months.find { it.index == snappedIndex }?.value?.let { newMonth ->
-                  onSnappedDateChanged(SnappedDate.Month(localDate = snappedDate.withMonthNumber(newMonth), index = snappedIndex))
+                  notifySnappedDateChanged(SnappedDate.Month(localDate = snappedDate.withMonthNumber(newMonth), index = snappedIndex))
                 }
               }
             )
@@ -201,7 +212,7 @@ internal fun CJKWheelDatePicker(
                 selectorProperties = WheelPickerDefaults.selectorProperties(
                   enabled = false
                 ),
-                startIndex = years.find { it.value == startDate.year }?.index ?: 0,
+                startIndex = years.find { it.value == initialDate.year }?.index ?: 0,
                 onScrollFinished = { snappedIndex ->
                   val newYear = years.find { it.index == snappedIndex }?.value
 
@@ -228,7 +239,7 @@ internal fun CJKWheelDatePicker(
                 },
                 onScrollChanged = { snappedIndex ->
                   years.find { it.index == snappedIndex }?.value?.let { newYear ->
-                    onSnappedDateChanged(SnappedDate.Year(localDate = snappedDate.withYear(newYear), index = snappedIndex))
+                    notifySnappedDateChanged(SnappedDate.Year(localDate = snappedDate.withYear(newYear), index = snappedIndex))
                   }
                 }
               )

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/SnappedChangeNotifier.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/SnappedChangeNotifier.kt
@@ -1,0 +1,16 @@
+package dev.darkokoa.datetimewheelpicker.core
+
+/**
+ * Deduplicates consecutive change notifications that resolve to the same key, so that
+ * multiple wheels reporting the same snapped value only notify the listener once.
+ */
+internal class SnappedChangeNotifier<K : Any> {
+
+  private var lastKey: K? = null
+
+  fun notifyIfChanged(key: K, notify: () -> Unit) {
+    if (key == lastKey) return
+    lastKey = key
+    notify()
+  }
+}

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/StandardWheelDatePicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/StandardWheelDatePicker.kt
@@ -47,7 +47,18 @@ internal fun StandardWheelDatePicker(
   val itemCount = if (yearsRange == null) 2 else 3
   val itemWidth = viewportSize.width / itemCount
 
-  var snappedDate by remember { mutableStateOf(startDate) }
+  val initialDate = remember(startDate, minDate, maxDate) {
+    startDate.coerceIn(minDate, maxDate)
+  }
+
+  var snappedDate by remember { mutableStateOf(initialDate) }
+
+  val snappedDateChangeNotifier = remember { SnappedChangeNotifier<LocalDate>() }
+  val notifySnappedDateChanged: (SnappedDate) -> Unit = { newSnappedDate ->
+    snappedDateChangeNotifier.notifyIfChanged(newSnappedDate.snappedLocalDate) {
+      onSnappedDateChanged(newSnappedDate)
+    }
+  }
 
   val dayOfMonths =
     rememberFormattedDayOfMonths(snappedDate.month.number, snappedDate.year, dateFormatter)
@@ -84,7 +95,7 @@ internal fun StandardWheelDatePicker(
               selectorProperties = WheelPickerDefaults.selectorProperties(
                 enabled = false
               ),
-              startIndex = dayOfMonths.find { it.value == startDate.day }?.index ?: 0,
+              startIndex = dayOfMonths.find { it.value == initialDate.day }?.index ?: 0,
               onScrollFinished = { snappedIndex ->
                 val newDayOfMonth = dayOfMonths.find { it.index == snappedIndex }?.value
 
@@ -111,7 +122,7 @@ internal fun StandardWheelDatePicker(
               },
               onScrollChanged = { snappedIndex ->
                 dayOfMonths.find { it.index == snappedIndex }?.value?.let { newDay ->
-                  onSnappedDateChanged(SnappedDate.DayOfMonth(localDate = snappedDate.withDayOfMonth(newDay), index = snappedIndex))
+                  notifySnappedDateChanged(SnappedDate.DayOfMonth(localDate = snappedDate.withDayOfMonth(newDay), index = snappedIndex))
                 }
               }
             )
@@ -132,7 +143,7 @@ internal fun StandardWheelDatePicker(
               selectorProperties = WheelPickerDefaults.selectorProperties(
                 enabled = false
               ),
-              startIndex = months.find { it.value == startDate.month.number }?.index ?: 0,
+              startIndex = months.find { it.value == initialDate.month.number }?.index ?: 0,
               onScrollFinished = { snappedIndex ->
                 val newMonth = months.find { it.index == snappedIndex }?.value
                 newMonth?.let {
@@ -164,7 +175,7 @@ internal fun StandardWheelDatePicker(
               },
               onScrollChanged = { snappedIndex ->
                 months.find { it.index == snappedIndex }?.value?.let { newMonth ->
-                  onSnappedDateChanged(SnappedDate.Month(localDate = snappedDate.withMonthNumber(newMonth), index = snappedIndex))
+                  notifySnappedDateChanged(SnappedDate.Month(localDate = snappedDate.withMonthNumber(newMonth), index = snappedIndex))
                 }
               }
             )
@@ -186,7 +197,7 @@ internal fun StandardWheelDatePicker(
                 selectorProperties = WheelPickerDefaults.selectorProperties(
                   enabled = false
                 ),
-                startIndex = years.find { it.value == startDate.year }?.index ?: 0,
+                startIndex = years.find { it.value == initialDate.year }?.index ?: 0,
                 onScrollFinished = { snappedIndex ->
                   val newYear = years.find { it.index == snappedIndex }?.value
 
@@ -219,7 +230,7 @@ internal fun StandardWheelDatePicker(
                 },
                 onScrollChanged = { snappedIndex ->
                   years.find { it.index == snappedIndex }?.value?.let { newYear ->
-                    onSnappedDateChanged(SnappedDate.Year(localDate = snappedDate.withYear(newYear), index = snappedIndex))
+                    notifySnappedDateChanged(SnappedDate.Year(localDate = snappedDate.withYear(newYear), index = snappedIndex))
                   }
                 }
               )

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/StandardWheelTimePicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/StandardWheelTimePicker.kt
@@ -63,10 +63,14 @@ internal fun StandardWheelTimePicker(
   val minutes = rememberMinutes(timeFormatter)
   val amPms = rememberAmPm(timeFormatter)
 
-  var snappedTime by remember { mutableStateOf(LocalTime(startTime.hour, startTime.minute)) }
+  val initialTime = remember(startTime, minTime, maxTime) {
+    LocalTime(startTime.hour, startTime.minute).coerceIn(minTime, maxTime)
+  }
+
+  var snappedTime by remember { mutableStateOf(initialTime) }
 
   var snappedAmPm by remember {
-    mutableStateOf(amPms.find { it.value == amPmValueFromTime(startTime) } ?: amPms[0])
+    mutableStateOf(amPms.find { it.value == amPmValueFromTime(initialTime) } ?: amPms[0])
   }
 
   fun resolveHour(index: Int): Int? =
@@ -103,8 +107,8 @@ internal fun StandardWheelTimePicker(
         selectedTextStyle = resolvedSelectedTextStyle,
         selectedTextColor = selectedTextColor,
         startIndex = if (timeFormatter.timeFormat == TimeFormat.HOUR_24) {
-          hours.find { it.value == startTime.hour }?.index ?: 0
-        } else amPmHours.find { it.value == localTimeToAmPmHour(startTime) }?.index ?: 0,
+          hours.find { it.value == initialTime.hour }?.index ?: 0
+        } else amPmHours.find { it.value == localTimeToAmPmHour(initialTime) }?.index ?: 0,
         selectorProperties = WheelPickerDefaults.selectorProperties(
           enabled = false
         ),
@@ -177,7 +181,7 @@ internal fun StandardWheelTimePicker(
         textColor = textColor,
         selectedTextStyle = resolvedSelectedTextStyle,
         selectedTextColor = selectedTextColor,
-        startIndex = minutes.find { it.value == startTime.minute }?.index ?: 0,
+        startIndex = minutes.find { it.value == initialTime.minute }?.index ?: 0,
         selectorProperties = WheelPickerDefaults.selectorProperties(
           enabled = false
         ),
@@ -242,7 +246,7 @@ internal fun StandardWheelTimePicker(
           textColor = textColor,
           selectedTextStyle = resolvedSelectedTextStyle,
           selectedTextColor = selectedTextColor,
-          startIndex = amPms.find { it.value == amPmValueFromTime(startTime) }?.index ?: 0,
+          startIndex = amPms.find { it.value == amPmValueFromTime(initialTime) }?.index ?: 0,
           selectorProperties = WheelPickerDefaults.selectorProperties(
             enabled = false
           ),

--- a/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
+++ b/datetime-wheel-picker/src/commonMain/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPicker.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isFinite
 import kotlin.math.abs
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 
 @Composable
@@ -52,17 +53,27 @@ internal fun WheelPicker(
     derivedStateOf { calculateSnappedItemIndex(lazyListState) }
   }
 
-  LaunchedEffect(lazyListState, count) {
+  LaunchedEffect(lazyListState) {
     snapshotFlow { snappedItemIndexState.value }
       .distinctUntilChanged()
+      .drop(1)
       .collect { latestOnScrollChanged(it) }
   }
 
-  LaunchedEffect(lazyListState, count) {
+  LaunchedEffect(lazyListState) {
     snapshotFlow { lazyListState.isScrollInProgress }
+      .distinctUntilChanged()
+      .drop(1)
       .filter { !it }
       .collect {
-        latestOnScrollFinished(calculateSnappedItemIndex(lazyListState))
+        // A finished drag may be immediately followed by a snap fling. Wait one frame so this
+        // drag-to-fling handoff gap is not misreported as a finished scroll, which would fire
+        // onScrollFinished twice for a single gesture.
+        withFrameNanos { }
+        if (lazyListState.isScrollInProgress) return@collect
+        val snappedIndex = calculateSnappedItemIndex(lazyListState)
+        latestOnScrollFinished(snappedIndex)
+          ?.takeIf { it != snappedIndex }
           ?.let { lazyListState.scrollToItem(it) }
       }
   }

--- a/datetime-wheel-picker/src/commonTest/kotlin/dev/darkokoa/datetimewheelpicker/core/SnappedChangeNotifierTest.kt
+++ b/datetime-wheel-picker/src/commonTest/kotlin/dev/darkokoa/datetimewheelpicker/core/SnappedChangeNotifierTest.kt
@@ -1,0 +1,58 @@
+package dev.darkokoa.datetimewheelpicker.core
+
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SnappedChangeNotifierTest {
+
+  @Test
+  fun firstKeyNotifies() {
+    val notifier = SnappedChangeNotifier<LocalDate>()
+    var notified = 0
+    notifier.notifyIfChanged(LocalDate(2025, 1, 31)) { notified++ }
+    assertEquals(1, notified)
+  }
+
+  @Test
+  fun repeatedKeyNotifiesOnlyOnce() {
+    val notifier = SnappedChangeNotifier<LocalDate>()
+    var notified = 0
+    repeat(3) {
+      notifier.notifyIfChanged(LocalDate(2025, 1, 31)) { notified++ }
+    }
+    assertEquals(1, notified)
+  }
+
+  @Test
+  fun changedKeyNotifiesAgain() {
+    val notifier = SnappedChangeNotifier<LocalDate>()
+    val notifiedDates = mutableListOf<LocalDate>()
+    val jan31 = LocalDate(2025, 1, 31)
+    val feb28 = LocalDate(2025, 2, 28)
+    notifier.notifyIfChanged(jan31) { notifiedDates += jan31 }
+    notifier.notifyIfChanged(feb28) { notifiedDates += feb28 }
+    assertEquals(listOf(jan31, feb28), notifiedDates)
+  }
+
+  @Test
+  fun returningToEarlierKeyNotifiesAgain() {
+    val notifier = SnappedChangeNotifier<LocalDate>()
+    var notified = 0
+    val jan31 = LocalDate(2025, 1, 31)
+    val feb28 = LocalDate(2025, 2, 28)
+    notifier.notifyIfChanged(jan31) { notified++ }
+    notifier.notifyIfChanged(feb28) { notified++ }
+    notifier.notifyIfChanged(jan31) { notified++ }
+    assertEquals(3, notified)
+  }
+
+  @Test
+  fun equalButNotSameInstanceKeyIsDeduplicated() {
+    val notifier = SnappedChangeNotifier<LocalDate>()
+    var notified = 0
+    notifier.notifyIfChanged(LocalDate(2025, 1, 31)) { notified++ }
+    notifier.notifyIfChanged(LocalDate(2025, 1, 31)) { notified++ }
+    assertEquals(1, notified)
+  }
+}

--- a/datetime-wheel-picker/src/jvmTest/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPickerCallbackTest.kt
+++ b/datetime-wheel-picker/src/jvmTest/kotlin/dev/darkokoa/datetimewheelpicker/core/WheelPickerCallbackTest.kt
@@ -1,0 +1,124 @@
+package dev.darkokoa.datetimewheelpicker.core
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.TouchInjectionScope
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipe
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Contract tests for [WheelPicker] callback timing, guarding against the regression in
+ * https://github.com/darkokoa/compose-datetime-wheel-picker/issues/71.
+ */
+@OptIn(ExperimentalTestApi::class)
+class WheelPickerCallbackTest {
+
+  // viewportSize height 300.dp with rowCount 3 => each item is exactly 100.dp tall.
+  private val viewportSize = DpSize(120.dp, 300.dp)
+  private val itemHeight = 100.dp
+
+  @Test
+  fun firstCompositionDoesNotFireCallbacks() = runComposeUiTest {
+    val changed = mutableListOf<Int>()
+    var finishedCount = 0
+    setContent {
+      WheelPicker(
+        count = 10,
+        rowCount = 3,
+        startIndex = 5,
+        viewportSize = viewportSize,
+        onScrollChanged = { changed += it },
+        onScrollFinished = { finishedCount++; null },
+      ) { index, _ -> Text("item-$index") }
+    }
+    waitForIdle()
+    assertTrue(changed.isEmpty(), "onScrollChanged must not fire on first composition, but got $changed")
+    assertEquals(0, finishedCount, "onScrollFinished must not fire on first composition")
+    onNodeWithText("item-5").assertIsDisplayed()
+  }
+
+  @Test
+  fun swipingOneItemFiresEachCallbackExactlyOnce() = runComposeUiTest {
+    val changed = mutableListOf<Int>()
+    val finished = mutableListOf<Int>()
+    setContent {
+      WheelPicker(
+        modifier = Modifier.testTag("wheel"),
+        count = 10,
+        rowCount = 3,
+        startIndex = 5,
+        viewportSize = viewportSize,
+        onScrollChanged = { changed += it },
+        onScrollFinished = { finished += it; null },
+      ) { index, _ -> Text("item-$index") }
+    }
+    onNodeWithTag("wheel").performTouchInput { swipeUpOneItem() }
+    waitForIdle()
+    assertEquals(listOf(6), changed, "onScrollChanged must fire exactly once with the new index")
+    assertEquals(listOf(6), finished, "onScrollFinished must fire exactly once with the new index")
+    onNodeWithText("item-6").assertIsDisplayed()
+  }
+
+  @Test
+  fun correctionReturnedFromOnScrollFinishedDoesNotFireSecondCallback() = runComposeUiTest {
+    val finished = mutableListOf<Int>()
+    setContent {
+      WheelPicker(
+        modifier = Modifier.testTag("wheel"),
+        count = 31,
+        rowCount = 3,
+        startIndex = 29,
+        viewportSize = viewportSize,
+        // Simulates a date picker correction, e.g. Jan 31 -> Feb snapping back to day 28.
+        onScrollFinished = { finished += it; 27 },
+      ) { index, _ -> Text("item-$index") }
+    }
+    onNodeWithTag("wheel").performTouchInput { swipeUpOneItem() }
+    waitForIdle()
+    assertEquals(listOf(30), finished, "the corrective scrollToItem must not re-fire onScrollFinished")
+    onNodeWithText("item-27").assertIsDisplayed()
+  }
+
+  @Test
+  fun correctionEqualToSnappedIndexKeepsWheelInPlace() = runComposeUiTest {
+    val finished = mutableListOf<Int>()
+    setContent {
+      WheelPicker(
+        modifier = Modifier.testTag("wheel"),
+        count = 10,
+        rowCount = 3,
+        startIndex = 5,
+        viewportSize = viewportSize,
+        onScrollFinished = { finished += it; it },
+      ) { index, _ -> Text("item-$index") }
+    }
+    onNodeWithTag("wheel").performTouchInput { swipeUpOneItem() }
+    waitForIdle()
+    assertEquals(listOf(6), finished)
+    onNodeWithText("item-6").assertIsDisplayed()
+  }
+
+  /**
+   * Swipes up by exactly one item height, slowly enough that the snap fling settles on the
+   * adjacent item instead of flinging across several items.
+   */
+  private fun TouchInjectionScope.swipeUpOneItem() {
+    swipe(
+      start = center,
+      end = center - Offset(0f, itemHeight.toPx()),
+      durationMillis = 1000
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the duplicate `onSnappedDate` callbacks reported in #71, plus two closely related callback-timing bugs found while writing regression tests for it. After this PR, each wheel callback fires **exactly once per user interaction**, and never during initial composition.

## Symptoms

- `onSnappedDate` fired **twice** when scrolling the month/year wheel across a day-count boundary (e.g. Jan 31 → Feb, or Feb 29 in a leap year → a non-leap year): once for the raw snap, once more after the internal day correction (#71).
- `onScrollChanged` / `onSnappedDateChanged` fired during **first composition**, when the wheels were merely being positioned at `startDate` / `startTime`.
- (Found by the new tests) A single slow drag could fire `onScrollFinished` **twice**: `isScrollInProgress` briefly flips to `false` in the gap between the end of the drag and the start of the snap fling, which was misreported as a finished scroll.

## Fix

All changes are in the internal `WheelPicker` and the date/time picker callback plumbing; no public API changes.

- **Suppress initial-composition callbacks**: the `snapshotFlow` that drives `onScrollChanged` now `drop(1)`s its initial emission.
- **Ignore the drag→fling handoff gap**: when `isScrollInProgress` turns `false`, wait one frame (`withFrameNanos`) and re-check before reporting `onScrollFinished`, so a drag immediately followed by a snap fling counts as one gesture.
- **Corrective repositioning doesn't re-fire callbacks**: when `onScrollFinished` returns a corrected index (e.g. Jan 31 → Feb snapping the day back to 28), the resulting `scrollToItem` no longer triggers a second callback.
- **Deduplicate `onSnappedDateChanged`**: consecutive notifications resolving to the same date (multiple columns reporting the same day) are collapsed via a small extracted `SnappedChangeNotifier`, which also removes verbatim duplication between `StandardWheelDatePicker` and `CJKWheelDatePicker`.
- **Coerce `startDate`/`startTime` into `min`/`max` bounds**, so the initial wheel position always matches the values later reported by callbacks.

### Note for reviewers: `LaunchedEffect` key change

The callback effects' key changed from `(lazyListState, count)` to `(lazyListState)`. This is intentional: if the effect restarted when `count` changes (e.g. the day column going 31 → 28 days), the `drop(1)` would swallow the next *real* callback. The flows must stay alive for the whole lifetime of the wheel.

## Tests

- **`WheelPickerCallbackTest` (jvmTest, 4 cases)** — contract tests against the internal `WheelPicker` using `runComposeUiTest` with precise one-item swipes:
  - first composition fires no callbacks;
  - a single swipe fires `onScrollChanged` / `onScrollFinished` exactly once each;
  - a corrected index returned from `onScrollFinished` repositions the wheel without a second callback (the core contract of #71);
  - returning the same index keeps the wheel in place.

  These tests are what uncovered the drag→fling double-fire race above (observed `[6, 6]` / `[30, 27]` before the fix). Verified deterministic: 5 consecutive `--rerun-tasks` runs, no flakes.
- **`SnappedChangeNotifierTest` (commonTest, 5 cases)** — pure unit tests for the dedup logic.
- Existing suites pass: `:datetime-wheel-picker:jvmTest` (66 tests), `testAndroidHostTest`; js / wasmJs / iosSimulatorArm64 test compilation verified.

## Out of scope

`StandardWheelTimePicker`'s `onSnappedTimeChanged` invokes its callback directly at three call sites without dedup. That is pre-existing 1.4.0 behavior and intentionally left untouched here.

Closes #71